### PR TITLE
Refresh FWER defaults, fix summary crash and ttest signatures

### DIFF
--- a/evalstats/api.py
+++ b/evalstats/api.py
@@ -23,7 +23,12 @@ from evalstats.config import get_alpha_ci, GRADIENT_CI_ALPHAS
 from evalstats.core.router import analyze, analyze_factorial, _analyze_single_lightweight
 from evalstats.core.bundles import AnalysisBundle, MultiModelBundle, AnalysisResult
 from evalstats.core.stats_utils import correct_pvalues
-from evalstats.core.summary import print_analysis_summary, print_brief_summary, _UNSET as _SUMMARY_UNSET
+from evalstats.core.summary import (
+    print_analysis_summary,
+    print_brief_summary,
+    _assign_significance_groups,
+    _UNSET as _SUMMARY_UNSET,
+)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -350,6 +355,56 @@ class ComparisonResult:
     def full_analysis(self):
         """Underlying AnalysisBundle (for vis function compatibility)."""
         return self._primary_bundle()
+
+    @property
+    def cross_model(self):
+        """Flat ranking over every (model, template) pair, or ``None``.
+
+        Populated only for two-factor comparisons (e.g.
+        ``factors=["model", "prompt"]``, or ``factors="model"`` when a
+        prompt column is also present). ``None`` for single-factor
+        comparisons. Call ``.summary()`` on the returned
+        :class:`~evalstats.core.bundles.AnalysisBundle` for the full
+        cross-model comparison — every (model, template) cell with its own
+        CI, ranked and grouped into statistically-indistinguishable bands,
+        the same "unbeaten" logic :attr:`unbeaten` applies within a single
+        factor, extended across both.
+        """
+        if isinstance(self._analysis, MultiModelBundle):
+            return self._analysis.cross_model
+        return None
+
+    @property
+    def best_pairs(self) -> Optional[list]:
+        """(model, template) pairs statistically tied for best, or ``None``.
+
+        This is the top significance group (``"#1"``) of :attr:`cross_model`
+        — every cell whose CI is not distinguishable from the top
+        performer's — not a single "best pair by mean". A higher point
+        estimate alone does not make one cell the winner over another it
+        isn't significantly different from; use this instead of manually
+        picking the row with the highest mean out of :attr:`cross_model`.
+        Mirrors :attr:`unbeaten` for the two-factor case: ``None`` when this
+        isn't a two-factor comparison, or when there are fewer than two
+        pairs to compare.
+        """
+        if not isinstance(self._analysis, MultiModelBundle):
+            return None
+        cross = self._analysis.cross_model
+        labels = list(cross.rank_dist.labels)
+        if len(labels) < 2:
+            return None
+        means = cross.robustness.mean
+        sort_idx = list(np.argsort(-means))
+        labels_sorted = [labels[i] for i in sort_idx]
+        label_to_group = _assign_significance_groups(cross.pairwise, labels_sorted, alpha=self._alpha)
+        top_pairs: list = []
+        for label in labels_sorted:
+            if label_to_group.get(label) == "#1":
+                parts = label.split(" / ", 1)
+                if len(parts) == 2:
+                    top_pairs.append((parts[0], parts[1]))
+        return top_pairs or None
 
     # ── data access ──────────────────────────────────────────────────────────
 

--- a/evalstats/api.py
+++ b/evalstats/api.py
@@ -1040,17 +1040,27 @@ def _run_alignment_ppi(
     correction: str,
     method: str,
     rng,
-    prefer: str = "bonferroni",
+    prefer: str = "auto",
 ) -> None:
     """Override CIs/p-values in ``cr._analysis`` in-place using Prediction-Powered
     Inference (PPI), by dispatching to the specific PPI-corrected implementation
     of whichever pairwise/robustness method applies (see
     ``_ppi_pairwise_dispatch``/``_ppi_robustness_dispatch`` above).
 
-    ``prefer`` mirrors ``_simultaneous_cis_router``'s knob of the same name:
-    Bonferroni is the default simultaneous-CI construction (faster, simpler,
-    and more robust at small N), and the joint bootstrap max-T correction is
-    only attempted when ``prefer="max_t"`` is passed explicitly.
+    ``prefer`` mirrors ``_simultaneous_cis_router``'s knob of the same name,
+    but PPI only ever has two constructions available (Bonferroni or its own
+    joint-bootstrap max-T) -- there is no PPI-corrected Sidak or joint-
+    bootstrap-with-effective-alpha the way the non-PPI path has (building and
+    validating one is real new work the cited simulations don't cover, since
+    they validate the raw/non-PPI tree only). ``prefer="auto"`` (default)
+    still follows fig:fwer-decision-tree's N-threshold logic -- Bonferroni
+    for small N (or a lopsided binary split regardless of N), else the
+    joint-bootstrap max-T -- just choosing between PPI's own two options
+    instead of Sidak/boot. Because of that narrower method roster, this is a
+    weaker guarantee than the non-PPI fix, and its calibration at the tree's
+    exact thresholds has not been independently simulated for the PPI-
+    corrected case (see TODO.md). Pass ``prefer="max_t"``/``"bonferroni"``
+    to force one directly, as before.
 
     For ``method="auto"`` the PPI-specific auto table
     (``evalstats.config.resolve_ppi_auto_methods``) picks a method validated
@@ -1272,10 +1282,22 @@ def _run_alignment_ppi(
     # when it succeeds, the per-pair loop can skip its redundant headline +
     # per-gradient-alpha dispatch calls entirely instead of computing them
     # only to immediately overwrite them.
+    #
+    # prefer="auto" resolves via the same N-threshold table the non-PPI path
+    # uses (see this function's docstring for why the *methods* chosen from
+    # that table differ -- Bonferroni/max-T here, not Sidak/boot).
+    resolved_prefer = prefer
+    if prefer == "auto":
+        from evalstats.core.resampling import is_lopsided_binary
+        from evalstats.config import resolve_auto_simultaneous_ci_method
+        _lopsided = data_kind == "binary" and is_lopsided_binary(scores_2d)
+        _tree_choice = resolve_auto_simultaneous_ci_method(data_kind, n_all, lopsided_binary=_lopsided)
+        resolved_prefer = "max_t" if _tree_choice == "boot" else "bonferroni"
+
     used_max_t = False
     joint = None
     if (
-        prefer == "max_t"
+        resolved_prefer == "max_t"
         and pairwise_method == "bootstrap_t"
         and use_simultaneous
         and not fallback_pairs
@@ -1395,7 +1417,7 @@ def _run_alignment_ppi(
     # a max-T p-value supersedes rather than stacks with this correction.
     if correction != "none" and n_pairs > 1:
         if not used_max_t:
-            pair_pvals = correct_pvalues(pair_pvals, correction)
+            pair_pvals = correct_pvalues(pair_pvals, correction, n_groups=len(labels))
 
         # Companion Wilcoxon p-values always get this correction as their own
         # family, regardless of max-T — matching all_pairwise()'s uncorrected
@@ -1403,7 +1425,15 @@ def _run_alignment_ppi(
         wsr_keys = [key for key in pair_keys if pair_wilcoxon_p[key] is not None]
         if len(wsr_keys) > 1:
             wsr_vals = np.array([pair_wilcoxon_p[key] for key in wsr_keys], dtype=float)
-            wsr_adj = correct_pvalues(wsr_vals, correction)
+            # Shaffer's needs the complete n_groups*(n_groups-1)/2 all-pairs
+            # set; wsr_keys can be a strict subset (e.g. no validated PPI
+            # Wilcoxon for an unpaired-fallback pair -- see above). Holm has
+            # no such requirement and is still FWER-valid for any subset.
+            _wsr_correction = (
+                "holm" if correction == "shaffer" and len(wsr_keys) != len(labels) * (len(labels) - 1) // 2
+                else correction
+            )
+            wsr_adj = correct_pvalues(wsr_vals, _wsr_correction, n_groups=len(labels))
             for key, adj_p in zip(wsr_keys, wsr_adj):
                 pair_wilcoxon_p[key] = float(adj_p)
 
@@ -1544,7 +1574,14 @@ def _run_judge_alignment_if_needed(
         alignment_result=ar,
         alpha=alpha,
         n_boot=max(n_mc, 1000),
-        correction=engine_kwargs.get("correction", "fdr_bh"),
+        # Default "shaffer", not "auto": PPI-corrected p-values are a flat
+        # array here (no raw per-item diffs matrix in scope the way
+        # all_pairwise() has), so romano_wolf_stepdown_pvalues (which needs
+        # that matrix) isn't reachable from this path -- see
+        # _run_alignment_ppi's docstring. Shaffer's applies at any N and is
+        # already a real improvement on the previous "fdr_bh" (FDR, not
+        # FWER) default.
+        correction=engine_kwargs.get("correction", "shaffer"),
         method=engine_kwargs.get("method", "auto"),
         rng=engine_kwargs.get("rng"),
     )
@@ -1613,6 +1650,9 @@ def compare(
         Also PPI-corrected when ``alignment=`` is passed.
     pairwise_test : {"auto", "bootstrap", "wilcoxon", "nemenyi"}
         Which p-value to show in the pairwise table. ``"auto"`` (default)
+        picks Wilcoxon signed-ranks when comparing exactly 2 entities (a
+        single pairwise comparison, per fig:fwer-decision-tree --
+        unconditionally, not just when ``omnibus=True``); with 3+ entities,
         picks bootstrap, or Wilcoxon when ``omnibus=True``. ``"nemenyi"``
         requires ``omnibus=True`` and is not supported together with
         ``alignment=`` (no validated PPI-corrected Nemenyi exists yet).

--- a/evalstats/api.py
+++ b/evalstats/api.py
@@ -1650,11 +1650,14 @@ def compare(
         Also PPI-corrected when ``alignment=`` is passed.
     pairwise_test : {"auto", "bootstrap", "wilcoxon", "nemenyi"}
         Which p-value to show in the pairwise table. ``"auto"`` (default)
-        picks Wilcoxon signed-ranks when comparing exactly 2 entities (a
-        single pairwise comparison, per fig:fwer-decision-tree --
-        unconditionally, not just when ``omnibus=True``); with 3+ entities,
-        picks bootstrap, or Wilcoxon when ``omnibus=True``. ``"nemenyi"``
-        requires ``omnibus=True`` and is not supported together with
+        always picks Wilcoxon signed-ranks, for any number of entities --
+        the standard workflow fig:fwer-decision-tree assumes throughout:
+        Friedman omnibus first when requested (``omnibus=True``), then
+        Wilcoxon for every pairwise comparison, then FWER-corrected as
+        post-hoc (see ``correction=`` on the underlying analysis engine).
+        Pass ``pairwise_test="bootstrap"`` explicitly for the CI-construction
+        method's own p-value instead. ``"nemenyi"`` requires ``omnibus=True``
+        and is not supported together with
         ``alignment=`` (no validated PPI-corrected Nemenyi exists yet).
     show_rank_probabilities : bool
         When ``True``, include the bootstrap "Rank Probabilities" block

--- a/evalstats/config.py
+++ b/evalstats/config.py
@@ -293,6 +293,152 @@ def resolve_ppi_auto_methods(data_kind: DataKind) -> tuple[str, str]:
     )
 
 
+# ---------------------------------------------------------------------------
+# FWER correction auto-routing (fig:fwer-decision-tree)
+# ---------------------------------------------------------------------------
+# Governs the k>=3 "family of comparisons" branch of the paper's FWER
+# decision tree: which simultaneous-CI construction (widens each pairwise
+# CI) and which p-value-correction procedure (adjusts each pairwise p-value)
+# evalstats picks automatically. The k=2 "single pairwise comparison" branch
+# (Wilcoxon signed-ranks, unconditionally -- no FWER control needed) is a
+# separate fix in compare()'s pairwise_test="auto" resolution, not covered
+# by either table here.
+#
+# Both tables key off a *lopsided_binary* flag (see
+# core.resampling.is_lopsided_binary: any compared group has fewer than 5
+# observed instances of its rarer 0/1 outcome) which forces the small-N
+# branch regardless of N or k -- resampling-based corrections (joint
+# bootstrap, Romano-Wolf) can misbehave when one outcome is that sparse,
+# while Sidak/Shaffer's closed-form adjustments stay reliable.
+#
+# The tree only distinguishes "binary" vs "numeric" data (not bounded_01 vs
+# unbounded separately) for the simultaneous-CI table -- both non-binary
+# DataKind values map to the "numeric" row below.
+
+
+@dataclass(frozen=True)
+class AutoSimultaneousCIRule:
+    """One row of the simultaneous-CI ``prefer="auto"`` routing matrix."""
+    data_kind: Literal["binary", "numeric"]
+    max_n: Optional[int]
+    method: str  # "sidak" or "boot" (joint bootstrap with effective alpha)
+    reason: str
+
+
+AUTO_SIMULTANEOUS_CI_METHOD_TABLE: tuple[AutoSimultaneousCIRule, ...] = (
+    AutoSimultaneousCIRule(
+        data_kind="binary", max_n=50,
+        method="sidak",
+        reason=(
+            "Binary data, N < 50: Sidak's closed-form, independence-based "
+            "adjustment stays well-calibrated and avoids the joint "
+            "bootstrap's small-N instability."
+        ),
+    ),
+    AutoSimultaneousCIRule(
+        data_kind="binary", max_n=None,
+        method="boot",
+        reason=(
+            "Binary data, N >= 50: joint bootstrap with an effective alpha "
+            "(_joint_bootstrap_scaled_simultaneous_cis) accounts for "
+            "correlation between comparisons that Sidak cannot."
+        ),
+    ),
+    AutoSimultaneousCIRule(
+        data_kind="numeric", max_n=30,
+        method="sidak",
+        reason="Numeric data, N < 30: Sidak.",
+    ),
+    AutoSimultaneousCIRule(
+        data_kind="numeric", max_n=None,
+        method="boot",
+        reason="Numeric data, N >= 30: joint bootstrap with effective alpha.",
+    ),
+)
+
+
+def resolve_auto_simultaneous_ci_method(
+    data_kind: DataKind, n: int, *, lopsided_binary: bool = False,
+) -> str:
+    """Resolve simultaneous-CI ``prefer="auto"`` to a concrete method.
+
+    Parameters
+    ----------
+    data_kind : "binary", "bounded_01", or "unbounded"
+        Detected data type. The FWER tree only distinguishes "binary" vs
+        "numeric" -- ``"bounded_01"``/``"unbounded"`` both map to the
+        "numeric" row.
+    n : int
+        Per-entity sample size (number of items).
+    lopsided_binary : bool
+        When True, forces ``"sidak"`` regardless of N -- the tree's
+        exception for a heavily skewed binary split, which applies
+        "regardless of n or k".
+
+    Returns
+    -------
+    str
+        ``"sidak"`` or ``"boot"``.
+    """
+    tree_kind = "binary" if data_kind == "binary" else "numeric"
+    if tree_kind == "binary" and lopsided_binary:
+        return "sidak"
+    for rule in AUTO_SIMULTANEOUS_CI_METHOD_TABLE:
+        if rule.data_kind != tree_kind:
+            continue
+        if rule.max_n is not None and n >= rule.max_n:
+            continue
+        return rule.method
+    raise AssertionError(
+        f"no AUTO_SIMULTANEOUS_CI_METHOD_TABLE rule matched data_kind={tree_kind!r}, n={n}"
+    )
+
+
+@dataclass(frozen=True)
+class AutoPValueCorrectionRule:
+    """One row of the k>=3 p-value-correction ``correction="auto"`` routing matrix."""
+    max_n: Optional[int]
+    method: str  # "shaffer" or "romano_wolf"
+    reason: str
+
+
+AUTO_PVALUE_CORRECTION_METHOD_TABLE: tuple[AutoPValueCorrectionRule, ...] = (
+    AutoPValueCorrectionRule(
+        max_n=30, method="shaffer",
+        reason="N < 30: Shaffer's modified step-down Holm procedure.",
+    ),
+    AutoPValueCorrectionRule(
+        max_n=None, method="romano_wolf",
+        reason=(
+            "N >= 30: Romano-Wolf bootstrap step-down, which strictly "
+            "dominates single-step corrections in power under positive "
+            "correlation between comparisons -- the common case for "
+            "repeated-measures/shared-item eval designs."
+        ),
+    ),
+)
+
+
+def resolve_auto_pvalue_correction_method(n: int, *, lopsided_binary: bool = False) -> str:
+    """Resolve k>=3 p-value ``correction="auto"`` to a concrete method.
+
+    ``lopsided_binary`` forces ``"shaffer"`` regardless of N -- the tree's
+    binary-data exception for the p-value-correction branch.
+
+    Returns
+    -------
+    str
+        ``"shaffer"`` or ``"romano_wolf"``.
+    """
+    if lopsided_binary:
+        return "shaffer"
+    for rule in AUTO_PVALUE_CORRECTION_METHOD_TABLE:
+        if rule.max_n is not None and n >= rule.max_n:
+            continue
+        return rule.method
+    raise AssertionError(f"no AUTO_PVALUE_CORRECTION_METHOD_TABLE rule matched n={n}")
+
+
 def set_alpha_ci(alpha: float) -> None:
     """Set the default significance level used across all CI analyses.
 

--- a/evalstats/core/mixed_effects.py
+++ b/evalstats/core/mixed_effects.py
@@ -323,7 +323,9 @@ def _apply_pvalue_correction(
     results: dict,
     pairs: list,
     correction: str,
-) -> None:
+    *,
+    n_groups: Optional[int] = None,
+) -> str:
     """Apply multiple-comparisons correction to a ``results`` dict in-place.
 
     Parameters
@@ -337,13 +339,32 @@ def _apply_pvalue_correction(
         used to extract and replace p-values in a consistent order.
     correction : str
         Correction method accepted by :func:`correct_pvalues` (e.g.
-        ``'holm'``, ``'bonferroni'``, ``'fdr_bh'``, ``'none'``).
-        When ``'none'`` or ``len(pairs) <= 1`` the function is a no-op.
+        ``'holm'``, ``'bonferroni'``, ``'fdr_bh'``, ``'shaffer'``,
+        ``'none'``), or ``'auto'``. ``'auto'`` always resolves to
+        ``'shaffer'`` here -- unlike :func:`~evalstats.core.paired.all_pairwise`'s
+        N-threshold-routed "auto" (which can pick Romano-Wolf step-down at
+        N>=30), the LMM path's Wald p-values have no raw bootstrap
+        distribution to build a step-down from, so this always picks the
+        one auto-table method that doesn't need one -- still a real
+        improvement on the previous unconditional ``'fdr_bh'`` (FDR, not
+        FWER) default. When ``'none'`` or ``len(pairs) <= 1`` the function
+        is a no-op (returns the resolved method without correcting anything).
+    n_groups : int, optional
+        Number of arms/groups being compared -- forwarded to
+        :func:`correct_pvalues` (required for ``'shaffer'``).
+
+    Returns
+    -------
+    str
+        The resolved correction method actually applied (e.g. ``'auto'``
+        resolves to ``'shaffer'``) -- callers should store this, not the
+        original *correction* argument, in ``PairwiseMatrix.correction_method``.
     """
-    if correction == "none" or len(pairs) <= 1:
-        return
+    resolved = "shaffer" if correction == "auto" else correction
+    if resolved == "none" or len(pairs) <= 1:
+        return resolved
     p_values = np.array([results[p].p_value for p in pairs])
-    adjusted = correct_pvalues(p_values, correction)
+    adjusted = correct_pvalues(p_values, resolved, n_groups=n_groups)
     for pair, adj_p in zip(pairs, adjusted):
         r = results[pair]
         results[pair] = PairedDiffResult(
@@ -354,12 +375,13 @@ def _apply_pvalue_correction(
             ci_low=r.ci_low,
             ci_high=r.ci_high,
             p_value=float(adj_p),
-            test_method=f"{r.test_method} ({correction}-corrected)",
+            test_method=f"{r.test_method} ({resolved}-corrected)",
             n_inputs=r.n_inputs,
             per_input_diffs=r.per_input_diffs,
             n_runs=r.n_runs,
             statistic=r.statistic,
         )
+    return resolved
 
 
 def _compute_raw_advantages_and_spread(
@@ -504,8 +526,8 @@ def _lmm_to_pairwise(
             "Check that template labels are simple strings without ' - '."
         )
 
-    _apply_pvalue_correction(results, pairs, correction)
-    return PairwiseMatrix(labels=labels, results=results, correction_method=correction)
+    _resolved_correction = _apply_pvalue_correction(results, pairs, correction, n_groups=len(labels))
+    return PairwiseMatrix(labels=labels, results=results, correction_method=_resolved_correction)
 
 
 # ---------------------------------------------------------------------------
@@ -921,8 +943,8 @@ def _lmm_to_pairwise_sm(
     if not results:
         raise RuntimeError("statsmodels LMM returned no usable contrasts.")
 
-    _apply_pvalue_correction(results, pairs, correction)
-    return PairwiseMatrix(labels=labels, results=results, correction_method=correction)
+    _resolved_correction = _apply_pvalue_correction(results, pairs, correction, n_groups=len(labels))
+    return PairwiseMatrix(labels=labels, results=results, correction_method=_resolved_correction)
 
 
 def _build_lmm_info_sm(sm_result: Any, n_obs: int) -> LMMInfo:
@@ -1587,8 +1609,8 @@ def _lmm_to_pairwise_factorial_sm(
     if not results:
         raise RuntimeError("Factorial LMM produced no usable pairwise contrasts.")
 
-    _apply_pvalue_correction(results, pairs, correction)
-    return PairwiseMatrix(labels=labels, results=results, correction_method=correction)
+    _resolved_correction = _apply_pvalue_correction(results, pairs, correction, n_groups=len(labels))
+    return PairwiseMatrix(labels=labels, results=results, correction_method=_resolved_correction)
 
 
 def _lmm_analyze_factorial_sm(
@@ -1988,8 +2010,8 @@ def _lmm_to_pairwise_factorial_pymer4(
     if not results:
         raise RuntimeError("Factorial LMM (pymer4) produced no usable pairwise contrasts.")
 
-    _apply_pvalue_correction(results, pairs, correction)
-    return PairwiseMatrix(labels=labels, results=results, correction_method=correction)
+    _resolved_correction = _apply_pvalue_correction(results, pairs, correction, n_groups=len(labels))
+    return PairwiseMatrix(labels=labels, results=results, correction_method=_resolved_correction)
 
 
 def _lmm_analyze_factorial_pymer4(

--- a/evalstats/core/paired.py
+++ b/evalstats/core/paired.py
@@ -40,18 +40,23 @@ from .resampling import (
     resolve_resampling_method,
     newcombe_paired_ci,
     tango_paired_ci,
+    tango_paired_ci_from_diffs,
     tango_paired_ci_multirun_effective,
     t_interval_ci_1d,
     logit_t_ci_1d,
     bayes_paired_diff_ci,
     is_binary_scores,
+    is_lopsided_binary,
     _stat,
     _nested_cell_mean_diffs,
     _reduce_rows,
     _weighted_medians_rows,
 )
 from .stats_utils import correct_pvalues, rescaled_ci
-from ..config import get_alpha_ci, GRADIENT_CI_ALPHAS, MAX_T_AUTO_METHOD
+from ..config import (
+    get_alpha_ci, GRADIENT_CI_ALPHAS, MAX_T_AUTO_METHOD,
+    resolve_auto_simultaneous_ci_method, resolve_auto_pvalue_correction_method,
+)
 
 
 BAYES_BINARY_LARGE_N_THRESHOLD = 200
@@ -1764,6 +1769,115 @@ def _joint_bootstrap_scaled_simultaneous_cis(
     return {pair: ci_func(results[pair].per_input_diffs, alpha_eff) for pair in pairs}
 
 
+def romano_wolf_stepdown_pvalues(
+    results: dict[tuple[str, str], "PairedDiffResult"],
+    pairs: list[tuple[str, str]],
+    n_bootstrap: int,
+    rng: "np.random.Generator",
+    *,
+    statistic: Literal["mean", "median"] = "mean",
+    batch_size: int = 256,
+) -> dict[tuple[str, str], float]:
+    """Romano & Wolf (2005)'s bootstrap step-down FWER-adjusted p-values.
+
+    Unlike single-step max-T (one joint critical value for every pair, see
+    :func:`_max_stat_simultaneous_cis`) or Sidak/Bonferroni (independence-
+    assuming, closed-form), the step-down refinement here recomputes the max
+    only over pairs not yet rejected at each step -- starting from the pair
+    with the largest observed studentized statistic and working down -- which
+    strictly dominates single-step corrections in power for the same strong
+    FWER guarantee. This is exactly the "recover power lost to a
+    correlation-blind correction" case repeated-measures eval designs create,
+    since shared items make every pair's diffs correlated. Per
+    fig:fwer-decision-tree, this is the recommended p-value-correction
+    procedure for k>=3 comparisons at N>=30 (see
+    :func:`~evalstats.config.resolve_auto_pvalue_correction_method`).
+
+    Ported from (and structurally identical to -- same shared-index,
+    per-replicate-studentized bootstrap-t construction, same step-down
+    reduction) the implementation in
+    ``simulations/harness/cases/pvalues.py``'s
+    ``_bootstrap_t_matrix``/``_stepdown_max_t_pvalues``, used to generate
+    this method's own validation numbers. Omits that version's Monte-Carlo-
+    throughput micro-optimizations (a BLAS-matmul resampling trick, RNG-draw
+    sharing with other corrections computed in the same simulation sweep) --
+    unnecessary at :func:`compare`'s scale -- in favor of a plain gather-
+    based resample, which the harness's own docstring notes its optimized
+    form was independently verified bit-close against. Only the "mean"/
+    per-item-bootstrap construction the auto-routing table selects is
+    implemented here, not the harness's permutation-based Westfall-Young
+    variant.
+
+    Parameters
+    ----------
+    results : dict[tuple[str, str], PairedDiffResult]
+        Already-computed pairwise results (as built by :func:`all_pairwise`);
+        only ``per_input_diffs`` is used, so this works regardless of which
+        *method* produced the raw pairwise matrix.
+    pairs : list[tuple[str, str]]
+        All pairs to jointly step down over, in the canonical
+        ``(label_a, label_b)`` storage order.
+    n_bootstrap : int
+        Number of bootstrap replicates.
+    rng : np.random.Generator
+    statistic : {"mean", "median"}
+        Central-tendency statistic each pair's point estimate uses.
+    batch_size : int
+        Bootstrap replicates processed per chunk (bounds peak memory for
+        large ``k * n_bootstrap * n_items`` -- mirrors the chunking already
+        used elsewhere in this module, e.g. :func:`_ppi_bootstrap_t_joint_stats`).
+
+    Returns
+    -------
+    dict[tuple[str, str], float]
+        Maps each pair to its Romano-Wolf FWER-adjusted p-value, monotonized
+        via a running max along the testing order (the same reformulation
+        Holm's own adjusted p-values use) so they are directly comparable to
+        alpha. Returns an empty dict when there are no pairs.
+    """
+    k = len(pairs)
+    if k == 0:
+        return {}
+
+    diffs_mat = np.stack([results[pair].per_input_diffs for pair in pairs], axis=0)  # (k, m)
+    m = diffs_mat.shape[1]
+
+    means = diffs_mat.mean(axis=1) if statistic == "mean" else np.median(diffs_mat, axis=1)
+    ses = diffs_mat.std(axis=1, ddof=1) / np.sqrt(m)
+    ses_safe = np.where(ses > 1e-12, ses, 1.0)
+    t_obs = np.abs(means) / ses_safe
+
+    b_means = np.empty((k, n_bootstrap))
+    b_ses_safe = np.empty((k, n_bootstrap))
+    start = 0
+    while start < n_bootstrap:
+        stop = min(start + batch_size, n_bootstrap)
+        b = stop - start
+        idx = rng.integers(0, m, size=(b, m))  # shared across all pairs
+        resampled = diffs_mat[:, idx]  # (k, b, m)
+        chunk_means = resampled.mean(axis=2) if statistic == "mean" else np.median(resampled, axis=2)
+        chunk_ses = resampled.std(axis=2, ddof=1) / np.sqrt(m)
+        b_means[:, start:stop] = chunk_means
+        b_ses_safe[:, start:stop] = np.where(chunk_ses > 1e-12, chunk_ses, 1.0)
+        start = stop
+
+    t_abs = np.abs((b_means - means[:, np.newaxis]) / b_ses_safe)  # (k, B)
+
+    order = np.argsort(-t_obs)  # descending observed |t|: tested first
+    t_abs_sorted = t_abs[order]  # (k, B)
+    # suffix_max[step] = max over pairs tested at or after `step` -- the
+    # step-down "remaining hypotheses" set, per bootstrap draw.
+    suffix_max = np.maximum.accumulate(t_abs_sorted[::-1], axis=0)[::-1]  # (k, B)
+    t_obs_sorted = t_obs[order]
+    extreme_counts = (suffix_max >= t_obs_sorted[:, np.newaxis]).sum(axis=1)  # (k,)
+    raw_step_p_sorted = (extreme_counts + 1) / (n_bootstrap + 1)
+    adjusted_sorted = np.minimum(np.maximum.accumulate(raw_step_p_sorted), 1.0)
+
+    adjusted = np.empty(k)
+    adjusted[order] = adjusted_sorted
+    return {pair: float(adjusted[i]) for i, pair in enumerate(pairs)}
+
+
 # Methods for which _max_stat_simultaneous_cis can produce bootstrap CIs.
 _SIMULTANEOUS_CI_BOOTSTRAP_METHODS = {
     "bootstrap", "bca", "bayes_bootstrap", "smooth_bootstrap", "bootstrap_t",
@@ -1782,43 +1896,55 @@ def _simultaneous_cis_router(
     rng: "np.random.Generator",
     statistic: str,
     *,
-    prefer: str = "bonferroni",
+    prefer: str = "auto",
+    score_range: Optional[tuple[float, float]] = None,
 ) -> tuple[dict[tuple[str, str], tuple[float, float]], str, dict]:
     """Route simultaneous CI computation to the requested construction.
 
-    Defaults to Bonferroni t-intervals (:func:`_bonferroni_simultaneous_cis`)
-    for every *method*, including bootstrap-compatible ones. This used to
-    default to the studentized bootstrap max-T method
-    (:func:`_max_stat_simultaneous_cis`) for bootstrap-compatible methods, on
-    the theory that accounting for correlation between comparisons would
-    make it less conservative than Bonferroni. Real-eval-data comparisons
-    (``simulations/harness/cases/pvalues.py``'s ``--mode simultaneous_ci``)
-    found that gain to be small and inconsistent in practice, while max-T's
-    ``bootstrap_t`` studentization has a documented instability at small N
-    combined with many simultaneous comparisons: resampling just N points to
-    re-estimate a per-replicate SE gets noisy, and taking a max over
-    k(k-1)/2 pairs multiplies the chances of hitting a near-zero denominator
-    on any one replicate. In that regime it becomes wildly wasteful (over-
-    covering at large width, not unsafe -- it never under-covers) rather
-    than the more powerful alternative it was meant to be. Bonferroni is
-    also a closed-form t-interval -- no bootstrap resampling at all -- so
-    it's cheaper and doesn't require the point-estimate method to be
-    bootstrap-compatible in the first place.
+    ``prefer="auto"`` (default) follows fig:fwer-decision-tree: Sidak for
+    small N (binary N<50, numeric N<30) or a lopsided binary split
+    regardless of N (see :func:`~evalstats.config.resolve_auto_simultaneous_ci_method`),
+    else joint bootstrap with an effective alpha (``"boot"``,
+    :func:`_joint_bootstrap_scaled_simultaneous_cis`). Both widen whichever
+    canonical closed-form pairwise CI formula the data resolves to -- Tango
+    for binary data, logit-t for a known-bounded numeric range (*score_range*),
+    plain t-interval as the bounds-agnostic fallback for everything else --
+    the same per-data-kind formula :data:`~evalstats.config.AUTO_ANALYZE_METHOD_TABLE`
+    already uses for the *non*-simultaneous pairwise CI, so Sidak/boot always
+    widen the formula that would otherwise have been shown, regardless of
+    which resampling *method* (bootstrap, bca, ...) the point estimate
+    itself used.
 
-    Pass ``prefer="max_t"`` to opt back into the studentized bootstrap
-    construction for bootstrap-compatible methods (falls back to Bonferroni
-    regardless if the bootstrap path returns an empty/degenerate result, or
-    if *method* isn't bootstrap-compatible to begin with -- analytical
-    methods such as ``'newcombe'``, ``'tango'``, ``'bayes_binary'`` always
-    use Bonferroni).
+    Historical note: this used to default unconditionally to Bonferroni
+    (with the studentized bootstrap max-T method as the sole opt-in
+    alternative via ``prefer="max_t"``) -- max-T's ``bootstrap_t``
+    studentization has a documented instability at small N combined with
+    many simultaneous comparisons (resampling just N points to re-estimate
+    a per-replicate SE gets noisy, and taking a max over k(k-1)/2 pairs
+    multiplies the chances of hitting a near-zero denominator on any one
+    replicate), which is why it stayed opt-in rather than becoming this
+    table's default. Sidak/boot are unrelated to that instability -- they
+    don't restudentize per replicate -- and are validated in
+    ``simulations/harness/cases/pvalues.py`` (``--mode simultaneous_ci``,
+    ``CORR_SIDAK``/``CORR_BOOT``), which imports
+    :func:`_sidak_simultaneous_cis`/:func:`_joint_bootstrap_scaled_simultaneous_cis`
+    directly to generate the paper's fig:fwer-decision-tree numbers.
+
+    Pass ``prefer="max_t"`` to opt into the (separate, tree-unrelated)
+    studentized bootstrap construction for bootstrap-compatible methods, or
+    ``prefer="bonferroni"``/``"sidak"``/``"boot"`` to force one specific
+    construction directly. Any requested construction falls back to
+    Bonferroni if it returns an empty/degenerate result (e.g. max-T on a
+    non-bootstrap-compatible *method*, or a joint bootstrap with zero
+    variance on every pair).
 
     Returns
     -------
     tuple[dict, str, dict]
-        ``(cis, method_used, max_t_pvalues)`` where *method_used* is
-        ``'max_t'`` or ``'bonferroni'``.  *max_t_pvalues* maps each pair to
-        its max-T p-value when *method_used* is ``'max_t'``; empty dict
-        otherwise.
+        ``(cis, method_used, max_t_pvalues)`` where *method_used* is one of
+        ``'sidak'``, ``'boot'``, ``'max_t'``, or ``'bonferroni'`` (fallback).
+        *max_t_pvalues* maps each pair to its max-T p-value only when
+        *method_used* is ``'max_t'``; empty dict otherwise.
     """
     if prefer == "max_t" and method in _SIMULTANEOUS_CI_BOOTSTRAP_METHODS:
         cis, max_t_pvalues = _max_stat_simultaneous_cis(
@@ -1834,8 +1960,60 @@ def _simultaneous_cis_router(
         if cis:
             return cis, "max_t", max_t_pvalues
 
-    # Default (and fallback if the bootstrap path above returned empty):
-    # Bonferroni t-intervals work for any method.
+    elif prefer in ("auto", "sidak", "boot") and len(pairs) > 1:
+        # fig:fwer-decision-tree's Sidak/boot branch is explicitly scoped to
+        # "Family of comparisons (k>=3)" -- with a single pair (k=2, one
+        # comparison), there's no family to control FWER across, and
+        # Bonferroni/Sidak's adjustment is already an exact no-op at k=1
+        # (alpha_adj = 1-(1-alpha)**(1/1) = alpha). "boot" doesn't degenerate
+        # as cleanly (it studentizes via a joint bootstrap max, then
+        # translates the resulting critical value back through the normal
+        # CDF to get alpha_eff -- a step that can materially misestimate
+        # alpha_eff, and therefore over- or under-widen the interval, for
+        # non-normal single-pair resampling distributions, e.g. a heavily
+        # outlier-contaminated median), so route k=1 through the plain
+        # Bonferroni fallback below rather than attempting the k>=3-only
+        # constructions at all.
+        is_binary = is_binary_scores(scores)
+        if is_binary:
+            data_kind = "binary"
+        elif score_range is not None:
+            data_kind = "bounded_01"
+        else:
+            data_kind = "unbounded"
+
+        resolved = prefer
+        if prefer == "auto":
+            n_items = scores.shape[1]
+            lopsided = is_binary and is_lopsided_binary(scores)
+            resolved = resolve_auto_simultaneous_ci_method(
+                data_kind, n_items, lopsided_binary=lopsided,
+            )
+
+        if data_kind == "binary":
+            ci_func = tango_paired_ci_from_diffs
+        elif data_kind == "bounded_01":
+            diff_span = score_range[1] - score_range[0]
+            diff_lo, diff_hi = -diff_span, diff_span
+
+            def ci_func(diffs, alpha, _lo=diff_lo, _hi=diff_hi):
+                return rescaled_ci(logit_t_ci_1d, diffs, alpha, _lo, _hi)
+        else:
+            ci_func = t_interval_ci_1d
+
+        if resolved == "sidak":
+            cis = _sidak_simultaneous_cis(results=results, pairs=pairs, ci=ci, ci_func=ci_func)
+            if cis:
+                return cis, "sidak", {}
+        elif resolved == "boot":
+            cis = _joint_bootstrap_scaled_simultaneous_cis(
+                scores=scores, results=results, pairs=pairs, labels=labels,
+                ci=ci, n_bootstrap=n_bootstrap, rng=rng, ci_func=ci_func, statistic=statistic,
+            )
+            if cis:
+                return cis, "boot", {}
+
+    # Fallback (and prefer="bonferroni"): Bonferroni t-intervals work for any method.
     cis = _bonferroni_simultaneous_cis(results=results, pairs=pairs, ci=ci)
     return cis, "bonferroni", {}
 
@@ -1846,7 +2024,7 @@ def all_pairwise(
     method: Literal["bootstrap", "bca", "bayes_bootstrap", "smooth_bootstrap", "bootstrap_t", "auto", "newcombe", "tango", "bayes_binary", "permutation", "sign_test", "t_interval", "logit_t"] = "auto",
     ci: float = 0.95,
     n_bootstrap: int = 10_000,
-    correction: Literal["holm", "bonferroni", "fdr_bh", "none"] = "fdr_bh",
+    correction: Literal["auto", "holm", "bonferroni", "fdr_bh", "hochberg", "shaffer", "romano_wolf", "none"] = "auto",
     rng: Optional[np.random.Generator] = None,
     statistic: Literal["mean", "median"] = "mean",
     simultaneous_ci: bool = True,
@@ -1854,6 +2032,7 @@ def all_pairwise(
     multi_ci: bool = False,
     compute_wilcoxon: bool = True,
     score_range: Optional[tuple[float, float]] = None,
+    prefer: str = "auto",
 ) -> PairwiseMatrix:
     """Compute all pairwise comparisons with multiple comparisons correction.
 
@@ -1871,8 +2050,23 @@ def all_pairwise(
     n_bootstrap : int
         Number of bootstrap resamples.
     correction : str
-        Multiple comparisons correction: ``'fdr_bh'`` (default),
-        ``'holm'``, ``'bonferroni'``, or ``'none'``.
+        p-value correction across the k(k-1)/2 pairwise comparisons.
+        ``'auto'`` (default) follows fig:fwer-decision-tree: Shaffer's
+        modified step-down Holm procedure for N < 30 (or a lopsided binary
+        split regardless of N -- see
+        :func:`~evalstats.config.resolve_auto_pvalue_correction_method`),
+        else Romano-Wolf bootstrap step-down. Explicit alternatives:
+        ``'shaffer'``, ``'romano_wolf'``, ``'holm'``, ``'bonferroni'``,
+        ``'fdr_bh'`` (Benjamini-Hochberg FDR control, not FWER -- use when
+        the false discovery rate rather than the family-wise error rate is
+        the actual target), ``'hochberg'``, or ``'none'``.
+
+        ``'romano_wolf'`` needs genuine per-pair resampling (see
+        :func:`romano_wolf_stepdown_pvalues`) and so only corrects the
+        primary bootstrap-derived p-value; the companion Wilcoxon p-value
+        (``PairedDiffResult.wilcoxon_p``) falls back to Shaffer's for that
+        one field, since there's no validated Romano-Wolf-on-Wilcoxon
+        construction.
     rng : np.random.Generator, optional
         Random number generator for reproducibility.
     statistic : str
@@ -1880,27 +2074,23 @@ def all_pairwise(
         ``'mean'``.
     simultaneous_ci : bool
         When ``True``, replace individual pairwise CIs with simultaneous
-        (family-wise) CIs.  Defaults to Bonferroni t-intervals at the
-        ``1 − (1−α)/k`` level (computed from ``per_input_diffs``) for every
-        *method*, including bootstrap-compatible ones (``'bootstrap'``,
-        ``'bca'``, ``'bayes_bootstrap'``, ``'smooth_bootstrap'``,
-        ``'bootstrap_t'``, ``'permutation'``, ``'sign_test'``, ``'auto'``).
-
-        This used to default to the studentized bootstrap max-T method
-        (Romano-Wolf) for those bootstrap-compatible methods instead -- all
-        pairs share the same bootstrap resamples so the joint distribution
-        of ``max_{(i,j)} |T_ij^b|`` accounts for the correlation between
-        comparisons, in principle making it less conservative than
-        Bonferroni. Real-eval-data comparisons found that gain to be small
-        and inconsistent in practice, while its studentization has a
-        documented instability at small N combined with many simultaneous
-        comparisons (see :func:`_simultaneous_cis_router`'s docstring) --
-        so Bonferroni is now the default there too, and is also simpler and
-        cheaper (a closed-form t-interval, no bootstrap resampling at all).
+        (family-wise) CIs. Routes through :func:`_simultaneous_cis_router`
+        with ``prefer="auto"``, which follows fig:fwer-decision-tree: Sidak
+        for small N (binary N<50, numeric N<30) or a lopsided binary split
+        regardless of N, else joint bootstrap with an effective alpha
+        (``'boot'``) -- see that function's docstring for the full
+        rationale and the (separate, tree-unrelated) studentized bootstrap
+        max-T alternative available via a direct ``prefer="max_t"`` call.
 
         The method actually used is recorded in
-        :attr:`PairwiseMatrix.simultaneous_ci_method` (``'bonferroni'`` or
-        ``'max_t'``).
+        :attr:`PairwiseMatrix.simultaneous_ci_method` (``'sidak'``,
+        ``'boot'``, ``'max_t'``, or ``'bonferroni'`` as the ultimate
+        fallback).
+    prefer : str
+        Passed through to :func:`_simultaneous_cis_router`'s ``prefer=``
+        knob to force a specific simultaneous-CI construction instead of
+        the ``"auto"`` (default) table lookup: ``"sidak"``, ``"boot"``,
+        ``"max_t"``, or ``"bonferroni"``.
     omnibus : bool
         When ``True``, run the Friedman omnibus test (with Nemenyi post-hoc)
         alongside the pairwise comparisons.  Requires k ≥ 3.  Defaults to
@@ -1938,17 +2128,53 @@ def all_pairwise(
             pairs.append((labels[i], labels[j]))
 
     # Apply multiple comparisons correction to bootstrap p-values (and Wilcoxon if available).
-    if correction != "none" and len(pairs) > 1:
-        p_values = np.array([results[p].p_value for p in pairs])
-        adjusted = correct_pvalues(p_values, correction)
+    resolved_correction = correction
+    if correction == "auto":
+        _is_binary = is_binary_scores(scores)
+        _lopsided = _is_binary and is_lopsided_binary(scores)
+        resolved_correction = resolve_auto_pvalue_correction_method(
+            scores.shape[1], lopsided_binary=_lopsided,
+        )
 
-        # Correct Wilcoxon p-values independently (only for pairs where the test ran).
+    if resolved_correction != "none" and len(pairs) > 1:
+        p_values = np.array([results[p].p_value for p in pairs])
         wsr_pairs = [p for p in pairs if results[p].wilcoxon_p is not None]
-        if len(wsr_pairs) > 1:
-            wsr_pvals = np.array([results[p].wilcoxon_p for p in wsr_pairs], dtype=float)
-            wsr_adj_map = dict(zip(wsr_pairs, correct_pvalues(wsr_pvals, correction)))
+        wsr_pvals = (
+            np.array([results[p].wilcoxon_p for p in wsr_pairs], dtype=float)
+            if len(wsr_pairs) > 1 else None
+        )
+        # Shaffer's needs the *complete* n_groups*(n_groups-1)/2 all-pairs
+        # set -- the companion Wilcoxon field can be a strict subset of that
+        # (e.g. undefined for a pair with zero-variance identical diffs),
+        # in which case Shaffer's own count check would raise. Holm has no
+        # such requirement and is still FWER-valid for any subset, so it's
+        # the safe fallback specifically for that partial set.
+        _wsr_is_complete = len(wsr_pairs) == n * (n - 1) // 2
+        _wsr_method = lambda m: m if (m != "shaffer" or _wsr_is_complete) else "holm"
+
+        if resolved_correction == "romano_wolf":
+            # Needs genuine per-pair resampling (see
+            # romano_wolf_stepdown_pvalues), so only the primary bootstrap-
+            # derived p-value gets the validated step-down correction. The
+            # companion Wilcoxon p-value falls back to Shaffer's for that
+            # one field -- there's no validated Romano-Wolf-on-Wilcoxon
+            # construction (see all_pairwise's correction= docstring).
+            _rw_adj = romano_wolf_stepdown_pvalues(
+                results, pairs, n_bootstrap, rng, statistic=statistic,
+            )
+            adjusted = np.array([_rw_adj[p] for p in pairs])
+            wsr_adj_map = (
+                dict(zip(wsr_pairs, correct_pvalues(wsr_pvals, _wsr_method("shaffer"), n_groups=n)))
+                if wsr_pvals is not None
+                else {p: results[p].wilcoxon_p for p in wsr_pairs}
+            )
         else:
-            wsr_adj_map = {p: results[p].wilcoxon_p for p in wsr_pairs}
+            adjusted = correct_pvalues(p_values, resolved_correction, n_groups=n)
+            wsr_adj_map = (
+                dict(zip(wsr_pairs, correct_pvalues(wsr_pvals, _wsr_method(resolved_correction), n_groups=n)))
+                if wsr_pvals is not None
+                else {p: results[p].wilcoxon_p for p in wsr_pairs}
+            )
 
         for pair, adj_p in zip(pairs, adjusted):
             r = results[pair]
@@ -1972,8 +2198,8 @@ def all_pairwise(
                 multi_ci=r.multi_ci,
             )
 
-    # Simultaneous CIs: Bonferroni by default (see _simultaneous_cis_router's
-    # docstring for why max-T is no longer the default).
+    # Simultaneous CIs: Sidak/joint-bootstrap by default, per
+    # fig:fwer-decision-tree (see _simultaneous_cis_router's docstring).
     applied_simultaneous_ci = False
     applied_simultaneous_ci_method: Optional[str] = None
     if simultaneous_ci and len(pairs) > 0:
@@ -1987,15 +2213,17 @@ def all_pairwise(
             n_bootstrap=n_bootstrap,
             rng=rng,
             statistic=statistic,
+            score_range=score_range,
+            prefer=prefer,
         )
         if sim_cis:
             applied_simultaneous_ci = True
             applied_simultaneous_ci_method = sim_method
-            ci_label = (
-                "simultaneous CIs computed with max-T"
-                if sim_method == "max_t"
-                else "simultaneous CIs computed with Bonferroni"
-            )
+            ci_label = {
+                "max_t": "simultaneous CIs computed with max-T",
+                "sidak": "simultaneous CIs computed with Sidak's procedure",
+                "boot": "simultaneous CIs computed with a joint bootstrap (effective alpha)",
+            }.get(sim_method, "simultaneous CIs computed with Bonferroni")
             for pair, (ci_low, ci_high) in sim_cis.items():
                 r = results[pair]
                 results[pair] = PairedDiffResult(
@@ -2034,7 +2262,7 @@ def all_pairwise(
     return PairwiseMatrix(
         labels=labels,
         results=results,
-        correction_method=correction,
+        correction_method=resolved_correction,
         friedman=friedman,
         simultaneous_ci=applied_simultaneous_ci,
         simultaneous_ci_method=applied_simultaneous_ci_method,

--- a/evalstats/core/resampling.py
+++ b/evalstats/core/resampling.py
@@ -136,6 +136,48 @@ def is_binary_scores(scores: np.ndarray) -> bool:
     return bool(np.all((finite == 0.0) | (finite == 1.0)))
 
 
+def is_lopsided_binary(scores: np.ndarray, threshold: int = 5) -> bool:
+    """Return True if any compared group has fewer than *threshold* observed
+    instances of its rarer binary outcome (e.g. only 2 ones out of 40).
+
+    Small-sample binary comparisons with a heavily skewed 0/1 split are the
+    regime where resampling-based FWER corrections (joint bootstrap,
+    Romano-Wolf step-down) can misbehave -- too few of the rarer outcome
+    makes the bootstrap's resampled distribution degenerate or lumpy -- while
+    Sidak's closed-form, independence-based adjustment stays reliable. Used
+    to force the small-N branch of the FWER auto-routing tables regardless
+    of the overall sample size N or number of comparisons k (see
+    fig:fwer-decision-tree).
+
+    Parameters
+    ----------
+    scores : np.ndarray
+        Score array of shape ``(N_groups, M)`` or ``(N_groups, M, R)`` --
+        one row per compared entity/group. Assumed already known to be
+        binary (call :func:`is_binary_scores` first); non-binary values are
+        ignored rather than raising.
+    threshold : int
+        Minimum required observed count of the rarer outcome per group
+        (default 5, matching the "<5 expected observations" rule of thumb).
+
+    Returns
+    -------
+    bool
+        True if ANY group has ``min(n_ones, n_zeros) < threshold``.
+    """
+    n_groups = scores.shape[0]
+    for i in range(n_groups):
+        flat = scores[i].ravel()
+        finite = flat[np.isfinite(flat)]
+        if len(finite) == 0:
+            continue
+        n_ones = int(np.sum(finite == 1.0))
+        n_zeros = int(np.sum(finite == 0.0))
+        if min(n_ones, n_zeros) < threshold:
+            return True
+    return False
+
+
 def is_bounded_01_scores(scores: np.ndarray) -> bool:
     """Return True if all finite values in *scores* lie within [0, 1].
 

--- a/evalstats/core/router.py
+++ b/evalstats/core/router.py
@@ -41,9 +41,6 @@ from ..config import get_alpha_ci, resolve_auto_analyze_methods
 def _resolve_p_value_method(
     p_values: bool,
     pairwise_test: str,
-    omnibus: bool,
-    *,
-    k: Optional[int] = None,
 ) -> Optional[str]:
     """Resolve the effective p-value display method for the bundle.
 
@@ -52,22 +49,28 @@ def _resolve_p_value_method(
 
     Resolution rules:
     - If ``p_values=False`` and ``pairwise_test='auto'``: suppress (``None``).
-    - ``pairwise_test='bootstrap'``  → ``'boot'``
-    - ``pairwise_test='wilcoxon'``   → ``'wsr'``
+    - ``pairwise_test='bootstrap'``  → ``'boot'`` (explicit: always the
+      CI-construction method's own p-value, never redirected).
+    - ``pairwise_test='wilcoxon'``   → ``'wsr'`` (explicit: always Wilcoxon,
+      even when Romano-Wolf is the resolved FWER correction -- an explicit
+      request is never silently swapped for a different statistic; it just
+      keeps whatever valid correction Wilcoxon's own p-value got, which is
+      Shaffer's in that case since Romano-Wolf has no Wilcoxon-compatible
+      form).
     - ``pairwise_test='nemenyi'``    → ``'nem'``
-    - ``pairwise_test='auto'`` with ``p_values=True`` and ``k == 2`` (a
-      single pairwise comparison -- no family, no FWER correction to speak
-      of): always ``'wsr'`` (Wilcoxon signed-ranks), per
-      fig:fwer-decision-tree's "single pairwise comparison" branch --
-      unconditionally, not just when ``omnibus=True``. ``k`` is the number
-      of entities being compared; ``None`` when unknown (e.g. the
-      multi-model path, which has no single well-defined ``k``) falls
-      through to the ``k != 2`` rule below.
-    - ``pairwise_test='auto'`` with ``p_values=True`` and ``k != 2`` (or
-      unknown):
-        - ``omnibus=True``  → ``'wsr'`` (Wilcoxon is the standard Friedman post-hoc)
-        - otherwise        → ``'auto'`` (display layer picks: boot for bootstrap
-          paths, Wilcoxon for LMM/other paths)
+    - ``pairwise_test='auto'`` with ``p_values=True``: ``'auto'`` -- final
+      resolution deferred to print time (see ``core.summary``'s p-value-
+      column logic), since it depends on which FWER correction actually
+      fired for this bundle (Shaffer's vs. Romano-Wolf), which in turn
+      depends on N/data-kind and isn't known until :func:`~evalstats.core.paired.all_pairwise`
+      has run. The default is Wilcoxon signed-ranks for *any* k >= 2 (per
+      fig:fwer-decision-tree's standard workflow: Friedman omnibus first
+      when requested, then Wilcoxon pairwise, then FWER-corrected as
+      post-hoc), except when Romano-Wolf step-down is what actually
+      resolved -- it has no Wilcoxon-compatible joint construction (see
+      :func:`~evalstats.core.paired.romano_wolf_stepdown_pvalues`'s
+      docstring), so its own mean-based bootstrap-t p-value is shown
+      instead in that one case.
     """
     explicit = pairwise_test != "auto"
     if not p_values and not explicit:
@@ -78,11 +81,7 @@ def _resolve_p_value_method(
         return "wsr"
     if pairwise_test == "nemenyi":
         return "nem"
-    # pairwise_test == 'auto' with p_values=True
-    if k == 2:
-        return "wsr"
-    if omnibus:
-        return "wsr"
+    # pairwise_test == 'auto' with p_values=True -- resolved at print time.
     return "auto"
 
 
@@ -345,12 +344,7 @@ def analyze(
             stacklevel=2,
         )
 
-    # k is only well-defined for a plain single-factor comparison -- the
-    # multi-model path has no single "k" (it has separate model/template/
-    # cross-model views), so it falls through to _resolve_p_value_method's
-    # k != 2 rule unchanged.
-    _k = result.n_templates if isinstance(result, BenchmarkResult) else None
-    resolved_p_value_method = _resolve_p_value_method(p_values, pairwise_test, omnibus, k=_k)
+    resolved_p_value_method = _resolve_p_value_method(p_values, pairwise_test)
 
     kwargs = dict(
         reference=reference,

--- a/evalstats/core/router.py
+++ b/evalstats/core/router.py
@@ -42,6 +42,8 @@ def _resolve_p_value_method(
     p_values: bool,
     pairwise_test: str,
     omnibus: bool,
+    *,
+    k: Optional[int] = None,
 ) -> Optional[str]:
     """Resolve the effective p-value display method for the bundle.
 
@@ -53,7 +55,16 @@ def _resolve_p_value_method(
     - ``pairwise_test='bootstrap'``  → ``'boot'``
     - ``pairwise_test='wilcoxon'``   → ``'wsr'``
     - ``pairwise_test='nemenyi'``    → ``'nem'``
-    - ``pairwise_test='auto'`` with ``p_values=True``:
+    - ``pairwise_test='auto'`` with ``p_values=True`` and ``k == 2`` (a
+      single pairwise comparison -- no family, no FWER correction to speak
+      of): always ``'wsr'`` (Wilcoxon signed-ranks), per
+      fig:fwer-decision-tree's "single pairwise comparison" branch --
+      unconditionally, not just when ``omnibus=True``. ``k`` is the number
+      of entities being compared; ``None`` when unknown (e.g. the
+      multi-model path, which has no single well-defined ``k``) falls
+      through to the ``k != 2`` rule below.
+    - ``pairwise_test='auto'`` with ``p_values=True`` and ``k != 2`` (or
+      unknown):
         - ``omnibus=True``  → ``'wsr'`` (Wilcoxon is the standard Friedman post-hoc)
         - otherwise        → ``'auto'`` (display layer picks: boot for bootstrap
           paths, Wilcoxon for LMM/other paths)
@@ -68,6 +79,8 @@ def _resolve_p_value_method(
     if pairwise_test == "nemenyi":
         return "nem"
     # pairwise_test == 'auto' with p_values=True
+    if k == 2:
+        return "wsr"
     if omnibus:
         return "wsr"
     return "auto"
@@ -82,7 +95,7 @@ def analyze(
     backend: Literal["statsmodels", "pymer4"] = "statsmodels",
     ci: Optional[float] = None,
     n_bootstrap: int = 10_000,
-    correction: Literal["holm", "bonferroni", "fdr_bh", "none"] = "fdr_bh",
+    correction: Literal["auto", "holm", "bonferroni", "fdr_bh", "hochberg", "shaffer", "romano_wolf", "none"] = "auto",
     spread_percentiles: tuple[float, float] = (10, 90),
     failure_threshold: Optional[float] = None,
     rng: Optional[np.random.Generator] = None,
@@ -183,8 +196,15 @@ def analyze(
         ``method='lmm'`` this controls the number of parametric
         simulations used for the rank distribution.
     correction : str
-        Multiple comparisons correction: ``'fdr_bh'`` (default),
-        ``'holm'``, ``'bonferroni'``, or ``'none'``.
+        Multiple comparisons correction across pairwise p-values.
+        ``'auto'`` (default) follows fig:fwer-decision-tree: Shaffer's
+        step-down Holm procedure for N<30 (or a lopsided binary split
+        regardless of N), else Romano-Wolf bootstrap step-down. Explicit
+        alternatives: ``'shaffer'``, ``'romano_wolf'``, ``'holm'``,
+        ``'bonferroni'``, ``'fdr_bh'`` (FDR, not FWER control -- use when
+        that's the actual target), ``'hochberg'``, or ``'none'``. See
+        :func:`~evalstats.core.paired.all_pairwise`'s ``correction=``
+        docstring for the full routing rationale.
     simultaneous_ci : bool
         When ``True``, pairwise CIs are simultaneous (family-wise) rather
         than marginal. Bonferroni correction is used by default for all
@@ -325,7 +345,12 @@ def analyze(
             stacklevel=2,
         )
 
-    resolved_p_value_method = _resolve_p_value_method(p_values, pairwise_test, omnibus)
+    # k is only well-defined for a plain single-factor comparison -- the
+    # multi-model path has no single "k" (it has separate model/template/
+    # cross-model views), so it falls through to _resolve_p_value_method's
+    # k != 2 rule unchanged.
+    _k = result.n_templates if isinstance(result, BenchmarkResult) else None
+    resolved_p_value_method = _resolve_p_value_method(p_values, pairwise_test, omnibus, k=_k)
 
     kwargs = dict(
         reference=reference,
@@ -453,7 +478,7 @@ def analyze_factorial(
     run_col: Optional[str] = None,
     backend: Literal["statsmodels", "pymer4"] = "statsmodels",
     ci: Optional[float] = None,
-    correction: Literal["holm", "bonferroni", "fdr_bh", "none"] = "fdr_bh",
+    correction: Literal["auto", "holm", "bonferroni", "fdr_bh", "hochberg", "shaffer", "romano_wolf", "none"] = "fdr_bh",
     reference: str = "grand_mean",
     spread_percentiles: tuple[float, float] = (10, 90),
     failure_threshold: Optional[float] = None,
@@ -732,7 +757,7 @@ def _analyze_single(
     backend: Literal["statsmodels", "pymer4"],
     ci: float,
     n_bootstrap: int,
-    correction: Literal["holm", "bonferroni", "fdr_bh", "none"],
+    correction: Literal["auto", "holm", "bonferroni", "fdr_bh", "hochberg", "shaffer", "romano_wolf", "none"],
     spread_percentiles: tuple[float, float],
     failure_threshold: Optional[float],
     rng: np.random.Generator,
@@ -1009,7 +1034,7 @@ def _analyze_multi_model(
     backend: Literal["statsmodels", "pymer4"],
     ci: float,
     n_bootstrap: int,
-    correction: Literal["holm", "bonferroni", "fdr_bh", "none"],
+    correction: Literal["auto", "holm", "bonferroni", "fdr_bh", "hochberg", "shaffer", "romano_wolf", "none"],
     spread_percentiles: tuple[float, float],
     failure_threshold: Optional[float],
     rng: np.random.Generator,

--- a/evalstats/core/summary.py
+++ b/evalstats/core/summary.py
@@ -650,17 +650,22 @@ def _print_multi_model_summary(
     print()
     _print_loud_section("Cross-Model Ranking (all model/template pairs)")
     _print_model_template_matrix(bundle)
+
+    # Shared by the (optional) P(Best) block below and the unconditional
+    # "Mean Performance" listing further down -- computed once here so the
+    # latter doesn't depend on show_rank_probabilities being True.
+    p_best = bundle.cross_model.rank_dist.p_best
+    expected_ranks = bundle.cross_model.rank_dist.expected_ranks
+    rank_labels = bundle.cross_model.rank_dist.labels
+    rank_pairs = [_split_model_template_label(label) for label in rank_labels]
+    rank_bar_width = 14
+    n_ranked_items = len(rank_labels)
+    model_col_width = min(24, max(len(model) for model, _ in rank_pairs) + 2)
+    template_col_width = min(24, max(len(template) for _, template in rank_pairs) + 2)
+    top_indices = np.argsort(-p_best)
+    n_show = len(top_indices)
+
     if show_rank_probabilities:
-        p_best = bundle.cross_model.rank_dist.p_best
-        expected_ranks = bundle.cross_model.rank_dist.expected_ranks
-        rank_labels = bundle.cross_model.rank_dist.labels
-        rank_pairs = [_split_model_template_label(label) for label in rank_labels]
-        rank_bar_width = 14
-        n_ranked_items = len(rank_labels)
-        model_col_width = min(24, max(len(model) for model, _ in rank_pairs) + 2)
-        template_col_width = min(24, max(len(template) for _, template in rank_pairs) + 2)
-        top_indices = np.argsort(-p_best)
-        n_show = len(top_indices)
         _print_subsection(f"--- Rank Probabilities: All {n_show} by P(Best) ({_rank_method_label(bundle.cross_model)}) ---")
         print(
             f"  {'Model':<{model_col_width}s} "
@@ -773,13 +778,14 @@ def _print_model_template_matrix(bundle: MultiModelBundle) -> None:
     """Print a model × template score matrix (mean ±std, heat encoding)."""
     model_labels = bundle.benchmark.model_labels
     template_labels = bundle.benchmark.template_labels
+    cross = bundle.cross_model
 
     # Build (model, template) -> mean from the flat cross_model bundle.
     # Labels are formatted as "model / template" by get_flat_result().
     cell_mean: dict[tuple[str, str], float] = {}
     for label, m in zip(
-        bundle.cross_model.rank_dist.labels,
-        bundle.cross_model.robustness.mean,
+        cross.rank_dist.labels,
+        cross.robustness.mean,
     ):
         parts = label.split(" / ", 1)
         if len(parts) == 2:
@@ -787,8 +793,29 @@ def _print_model_template_matrix(bundle: MultiModelBundle) -> None:
 
     all_means = list(cell_mean.values())
     mn, mx = min(all_means), max(all_means)
-    best_mean = mx
     heat_chars = "·░▒▓█"
+
+    # Cells statistically tied for best -- the same CD-style significance-
+    # group analysis used by the executive summary below (group "#1"),
+    # rather than the single highest raw mean. A marginally higher point
+    # estimate should not read as a decisive winner when the pairwise CIs
+    # show it isn't distinguishable from its neighbors; that would defeat
+    # the point of reporting calibrated intervals in the first place.
+    cross_labels_all = list(cross.rank_dist.labels)
+    cross_means_all = cross.robustness.mean
+    sort_idx = list(np.argsort(-cross_means_all))
+    labels_sorted = [cross_labels_all[i] for i in sort_idx]
+    label_to_group = _assign_significance_groups(cross.pairwise, labels_sorted)
+    best_cells: set[tuple[str, str]] = set()
+    for label, group in label_to_group.items():
+        if group == "#1":
+            parts = label.split(" / ", 1)
+            if len(parts) == 2:
+                best_cells.add((parts[0], parts[1]))
+    if not best_cells:
+        # Fallback so a winner is still shown if group detection finds
+        # nothing (e.g. degenerate pairwise matrix).
+        best_cells = {max(cell_mean, key=cell_mean.get)}
 
     def _heat(v: float) -> str:
         if mx == mn:
@@ -806,9 +833,10 @@ def _print_model_template_matrix(bundle: MultiModelBundle) -> None:
             return f"{'N/A':^{CELL_W}}"
         m = cell_mean[(mdl, t)]
         h = _heat(m)
-        marker = "*" if m == best_mean else " "
+        is_best = (mdl, t) in best_cells
+        marker = "*" if is_best else " "
         plain = f"{m:.3f} {h}{marker}".rjust(CELL_W)
-        if m == best_mean:
+        if is_best:
             return f"{_BOLD}{_BRIGHT_GREEN}{plain}{_RESET}"
         return plain
 
@@ -829,7 +857,10 @@ def _print_model_template_matrix(bundle: MultiModelBundle) -> None:
 
     # Footer
     print(div)
-    print(f"  * = best pair by mean  |  heat: · (low) → █ (high), range [{mn:.3f}, {mx:.3f}]")
+    print(
+        f"  * = statistically tied for best (95% CI, not significantly beaten)  |  "
+        f"heat: · (low) → █ (high), range [{mn:.3f}, {mx:.3f}]"
+    )
     print()
 
 

--- a/evalstats/core/summary.py
+++ b/evalstats/core/summary.py
@@ -995,15 +995,28 @@ def _print_pairwise_section(
     # Whether simultaneous max-T CIs were used (affects p-value source for bootstrap paths).
     using_max_t = bundle.pairwise.simultaneous_ci_method == "max_t"
 
+    # Whether Romano-Wolf step-down was the FWER correction that actually
+    # fired for this bundle (only known post-hoc, once all_pairwise() has
+    # run -- see _resolve_p_value_method's docstring). Guarded on
+    # len(results) > 1 because all_pairwise() still resolves and reports
+    # correction_method="romano_wolf" for a single-pair (k=2) bundle even
+    # though nothing is actually corrected there (no family to correct
+    # across) -- Wilcoxon must stay the default at k=2 regardless of N.
+    is_romano_wolf_active = (
+        bundle.pairwise.correction_method == "romano_wolf"
+        and len(bundle.pairwise.results) > 1
+    )
+
     # Resolve the effective p-value source and column header.
     if p_value_method == "auto":
-        if is_newcombe_pairwise:
-            eff_p_source, p_col_header = "boot", "p (McNemar)"
-        elif is_sign_pairwise:
-            eff_p_source, p_col_header = "boot", "p (sign)"
-        elif is_bootstrap_path:
-            eff_p_source = "max_t" if using_max_t else "boot"
-            p_col_header = "p (boot)"
+        # Wilcoxon signed-ranks is the default pairwise test for any k >= 2
+        # (fig:fwer-decision-tree's standard workflow), *except* when
+        # Romano-Wolf step-down is the resolved correction -- it has no
+        # Wilcoxon-compatible joint construction (see
+        # romano_wolf_stepdown_pvalues's docstring) and produces its own
+        # mean-based bootstrap-t p-value instead, which is what's shown here.
+        if is_romano_wolf_active:
+            eff_p_source, p_col_header = "boot", "p (RW)"
         else:
             eff_p_source, p_col_header = "wsr", "p (wsr)"
     elif p_value_method == "boot":
@@ -1230,7 +1243,9 @@ def _print_pairwise_section(
     elif max_pairs > 0:
         print(f"{_DIM}  ES = Effect Size (r_rb) = rank biserial correlation (small≈0.1, medium≈0.3, large≈0.5){_RESET}")
         if eff_p_source in {"max_t", "boot"}:
-            if is_newcombe_pairwise:
+            if is_romano_wolf_active and eff_p_source == "boot":
+                print(f"  {p_col_header} = Romano-Wolf bootstrap step-down (FWER-controlled; no Wilcoxon-compatible joint form exists, see romano_wolf_stepdown_pvalues)")
+            elif is_newcombe_pairwise:
                 print(f"  {p_col_header} = McNemar exact test (two-sided, uncorrected)")
             elif is_sign_pairwise:
                 print(f"  {p_col_header} = paired sign test (two-sided exact, ties dropped, uncorrected)")

--- a/evalstats/tests/__init__.py
+++ b/evalstats/tests/__init__.py
@@ -3663,9 +3663,9 @@ def _ppi_friedman_ci(
 def ttest(
     a,
     b,
-    *,
     a_lab=None,
     b_lab=None,
+    *,
     paired: bool = False,
     equal_var: bool = False,
     alpha: float = 0.05,
@@ -3729,6 +3729,7 @@ def ttest(
     --------
     >>> result = es.tests.ttest(llm_a, llm_b)                          # prints
     >>> result = es.tests.ttest(llm_a, llm_b, print_result=False)      # silent
+    >>> result = es.tests.ttest(llm_a, llm_b, human_a, human_b)     # positional
     >>> result = es.tests.ttest(llm_a, llm_b, a_lab=human_a, b_lab=human_b)
     """
     a = _coerce(a)
@@ -3879,9 +3880,9 @@ def ttest(
 def mannwhitney(
     x,
     y,
-    *,
     x_lab=None,
     y_lab=None,
+    *,
     alpha: float = 0.05,
     n_boot: int = 2000,
     rng=None,
@@ -4153,6 +4154,7 @@ def mannwhitney(
     --------
     >>> result = es.tests.mannwhitney(llm_x, llm_y)                    # prints
     >>> result = es.tests.mannwhitney(llm_x, llm_y, print_result=False) # silent
+    >>> result = es.tests.mannwhitney(llm_x, llm_y, human_x, human_y)  # positional
     >>> result = es.tests.mannwhitney(llm_x, llm_y, x_lab=human_x, y_lab=human_y)
     """
     if method not in ("ridge", "adaptive", "local", "global", "mnar_experimental"):
@@ -4244,9 +4246,9 @@ def mannwhitney(
 def wilcoxon(
     x,
     y,
-    *,
     x_lab=None,
     y_lab=None,
+    *,
     alpha: float = 0.05,
     n_boot: int = 2000,
     rng=None,
@@ -4418,6 +4420,7 @@ def wilcoxon(
     --------
     >>> result = es.tests.wilcoxon(llm_x, llm_y)                      # prints
     >>> result = es.tests.wilcoxon(llm_x, llm_y, print_result=False)  # silent
+    >>> result = es.tests.wilcoxon(llm_x, llm_y, human_x, human_y)    # positional
     >>> result = es.tests.wilcoxon(llm_x, llm_y, x_lab=human_x, y_lab=human_y)
     """
     if method not in ("current", "hajek_experimental"):

--- a/simulations/harness/cases/ppi_real.py
+++ b/simulations/harness/cases/ppi_real.py
@@ -160,6 +160,7 @@ with warnings.catch_warnings():
     from evalstats.tests import (
         _ppi_single_bootstrap_t,
         _ppi_single_wilson,
+        _ppi_single_logit_t,
         _ppi_two_sample,
         _ppi_two_sample_midrank_corrected,
         _ppi_two_sample_adaptive,
@@ -168,6 +169,8 @@ with warnings.catch_warnings():
         _ppi_paired_bayes_bootstrap,
         _ppi_paired_bootstrap_t,
         _ppi_paired_tango,
+        _ppi_paired_t_interval,
+        _ppi_paired_logit_t,
         _p_x_gt_y_midrank,
         paired_walsh_midrank_theta,
         _ppi_anova_independent_p_value,
@@ -178,6 +181,7 @@ with warnings.catch_warnings():
 
 from ..methods import (
     TTEST, TTEST_WELCH, MWU, MWU_MNAR_EXPERIMENTAL, MWU_ADAPTIVE, MWU_RIDGE, WILCOXON, PAIRED_T, BAYES_BOOTSTRAP, BOOTSTRAP_T, TANGO,
+    PPI_T_INTERVAL, PPI_LOGIT_T,
     ANOVA_IND, ANOVA_REP, FRIEDMAN, KRUSKAL, PPI_TEST_METHODS, get_method_color,
 )
 from ..scenarios.real_judge_bias import (
@@ -272,6 +276,17 @@ def _run_real_single_cell(
                 except Exception:
                     pass
 
+            if PPI_LOGIT_T.name in methods:
+                try:
+                    # Closed-form logit-t, PPI_AUTO_METHOD_TABLE's "bounded_01"
+                    # robustness method (both judge and human are already
+                    # rescaled to [0, 1] -- see RealJudgeBiasCorpus) -- the
+                    # non-binary counterpart to the Wilson branch above.
+                    r = _ppi_single_logit_t(judge, lab, _ALPHA)
+                    out[PPI_LOGIT_T.name].append((r.estimate, r.ci_low, r.ci_high, r.llm_estimate))
+                except Exception:
+                    pass
+
     return dict(out)
 
 
@@ -361,7 +376,7 @@ def _run_real_paired_cell(
 ) -> tuple[dict[str, int], dict[str, int]]:
     """n_reps replicates of the paired Type-I null check (same items,
     scored by two DIFFERENT judges) -- mirrors pvalues.py's _run_ppi_cell
-    paired-groups branches (wilcoxon/paired_t/bayes_bootstrap/bootstrap_t/
+    paired-groups branches (wilcoxon/paired_t/ppi_t_interval/ppi_logit_t/
     tango). See generate_real_paired_null_cell for why this is an exact
     null rather than merely an equal-in-distribution one."""
     rng = np.random.default_rng(seed)
@@ -444,6 +459,24 @@ def _run_real_paired_cell(
                     uncorrected[TANGO.name] += int(p_u < _ALPHA)
                     r = _ppi_paired_tango(llm_x, llm_y, lab_x, lab_y, _ALPHA)
                     corrected[TANGO.name] += int(r.p_value < _ALPHA)
+                except Exception:
+                    pass
+
+            if PPI_T_INTERVAL.name in methods:
+                try:
+                    p_u = float(scipy_stats.ttest_rel(llm_x, llm_y).pvalue)
+                    uncorrected[PPI_T_INTERVAL.name] += int(p_u < _ALPHA)
+                    r = _ppi_paired_t_interval(llm_x, llm_y, lab_x, lab_y, _ALPHA)
+                    corrected[PPI_T_INTERVAL.name] += int(r.p_value < _ALPHA)
+                except Exception:
+                    pass
+
+            if PPI_LOGIT_T.name in methods:
+                try:
+                    p_u = float(scipy_stats.ttest_rel(llm_x, llm_y).pvalue)
+                    uncorrected[PPI_LOGIT_T.name] += int(p_u < _ALPHA)
+                    r = _ppi_paired_logit_t(llm_x, llm_y, lab_x, lab_y, _ALPHA)
+                    corrected[PPI_LOGIT_T.name] += int(r.p_value < _ALPHA)
                 except Exception:
                     pass
 
@@ -679,7 +712,7 @@ def _run_real_wmt_paired_power_cell(
     detection) instead of collecting (estimate, ci_low, ci_high,
     llm_estimate) tuples for a bias/coverage check like _run_real_wmt_
     paired_bias_cell does. Test battery mirrors _run_real_paired_cell's
-    paired-samples family (wilcoxon/paired_t/bayes_bootstrap/bootstrap_t;
+    paired-samples family (wilcoxon/paired_t/ppi_t_interval/ppi_logit_t;
     no tango -- see _WMT_PAIRED_POWER_METHODS)."""
     rng = np.random.default_rng(seed)
     corrected: dict[str, int] = {t: 0 for t in methods}
@@ -733,30 +766,56 @@ def _run_real_wmt_paired_power_cell(
                 except Exception:
                     pass
 
+            if PPI_T_INTERVAL.name in methods:
+                try:
+                    p_u = float(scipy_stats.ttest_rel(llm_x, llm_y).pvalue)
+                    uncorrected[PPI_T_INTERVAL.name] += int(p_u < _ALPHA)
+                    r = _ppi_paired_t_interval(llm_x, llm_y, lab_x, lab_y, _ALPHA)
+                    corrected[PPI_T_INTERVAL.name] += int(r.p_value < _ALPHA)
+                except Exception:
+                    pass
+
+            if PPI_LOGIT_T.name in methods:
+                try:
+                    p_u = float(scipy_stats.ttest_rel(llm_x, llm_y).pvalue)
+                    uncorrected[PPI_LOGIT_T.name] += int(p_u < _ALPHA)
+                    r = _ppi_paired_logit_t(llm_x, llm_y, lab_x, lab_y, _ALPHA)
+                    corrected[PPI_LOGIT_T.name] += int(r.p_value < _ALPHA)
+                except Exception:
+                    pass
+
     return corrected, uncorrected
 
 
-_WMT_PAIRED_BIAS_METHODS = [WILCOXON.name, PAIRED_T.name, BAYES_BOOTSTRAP.name]
-"""_paired_methods_for("continuous") minus BOOTSTRAP_T -- its test name
-("bootstrap_t") is IDENTICAL to _SINGLE_METHOD_BOOTSTRAP_T, which the
-single-sample bias/coverage check already uses for a totally different
-estimand (a population MEAN, not a population MEAN PAIRED DIFFERENCE).
-print_ppi_effect_report pools rows by test name only (not tag), so
-including it here would silently merge two unrelated checks' bias/
-coverage stats into one misleading "bootstrap_t" row. TANGO excluded for
-the same reason it's excluded from _paired_methods_for("continuous")."""
+_WMT_PAIRED_BIAS_METHODS = [WILCOXON.name, PAIRED_T.name, PPI_T_INTERVAL.name]
+"""_paired_methods_for("continuous") minus BAYES_BOOTSTRAP/BOOTSTRAP_T
+(removed 2026-08-07, no longer part of ppi_real's official CI-comparison
+set -- see _paired_methods_for) and minus PPI_LOGIT_T specifically: its
+test name ("ppi_logit_t") would be IDENTICAL to the single-sample bias/
+coverage check's own PPI_LOGIT_T branch, which targets a totally
+different estimand (a population MEAN, not a population MEAN PAIRED
+DIFFERENCE). print_ppi_effect_report pools rows by test name only (not
+tag), so including it here would silently merge two unrelated checks'
+bias/coverage stats into one misleading "ppi_logit_t" row -- the same
+collision problem BOOTSTRAP_T used to create here, just with a new name
+now that BOOTSTRAP_T itself is gone from the official set. PPI_T_INTERVAL
+has no such collision (nothing else in the official set uses it for a
+different estimand), so it's safe to include. TANGO excluded for the
+same eval_type restriction _paired_methods_for applies (this corpus is
+always eval_type="continuous_paired")."""
 
-_WMT_PAIRED_POWER_METHODS = [WILCOXON.name, PAIRED_T.name, BAYES_BOOTSTRAP.name, BOOTSTRAP_T.name]
-"""Unlike _WMT_PAIRED_BIAS_METHODS, BOOTSTRAP_T is safe to include here --
+_WMT_PAIRED_POWER_METHODS = [WILCOXON.name, PAIRED_T.name, PPI_T_INTERVAL.name, PPI_LOGIT_T.name]
+"""Unlike _WMT_PAIRED_BIAS_METHODS, PPI_LOGIT_T is safe to include here --
 power_results (a PPIResult bucket keyed by rejection COUNTS, not
-PPIEffectResult's bias/coverage stats) never mixes this check's "bootstrap_t"
-with the single-sample check's differently-estimand "bootstrap_t" the way
-print_ppi_effect_report's by-test-name pooling would; every "bootstrap_t"
-row across twogroup_power/paired power/omnibus power/this check already
-means the same thing (a paired- or independent-samples bootstrap-t test),
-same as hypothesis_results already does for the Type-I null checks. TANGO
-still excluded, for the same eval_type restriction _paired_methods_for
-applies (this corpus is always eval_type="continuous_paired")."""
+PPIEffectResult's bias/coverage stats) never mixes this check's
+"ppi_logit_t" with the single-sample check's differently-estimand
+"ppi_logit_t" the way print_ppi_effect_report's by-test-name pooling
+would; every "ppi_logit_t" row across twogroup_power/paired power/
+omnibus power/this check already means the same thing (a paired- or
+independent-samples logit-t test), same as hypothesis_results already
+does for the Type-I null checks. TANGO still excluded, for the same
+eval_type restriction _paired_methods_for applies (this corpus is
+always eval_type="continuous_paired")."""
 
 
 def _run_real_wmt_paired_bias_cell(
@@ -815,13 +874,20 @@ def _run_real_wmt_paired_bias_cell(
                 except Exception:
                     pass
 
-            # BOOTSTRAP_T deliberately NOT included here -- see
-            # _WMT_PAIRED_BIAS_METHODS' docstring (its test name collides
-            # with the single-sample check's _SINGLE_METHOD_BOOTSTRAP_T,
-            # which would silently pool two different estimands' stats
-            # together in print_ppi_effect_report). Not wired up at all,
-            # rather than left reachable-but-unused, since nothing calls
-            # this function with a methods list that would ever hit it.
+            if PPI_T_INTERVAL.name in methods:
+                try:
+                    r = _ppi_paired_t_interval(llm_x, llm_y, lab_x, lab_y, _ALPHA)
+                    out[PPI_T_INTERVAL.name].append((r.estimate, r.ci_low, r.ci_high, r.llm_estimate))
+                except Exception:
+                    pass
+
+            # BOOTSTRAP_T and PPI_LOGIT_T deliberately NOT included here --
+            # see _WMT_PAIRED_BIAS_METHODS' docstring (both would collide by
+            # test name with the single-sample check's own branches, which
+            # target a totally different estimand, and print_ppi_effect_
+            # report pools by test name only). Not wired up at all, rather
+            # than left reachable-but-unused, since nothing calls this
+            # function with a methods list that would ever hit them.
 
     return dict(out)
 
@@ -906,7 +972,18 @@ def _run_ppi_real_cell_worker(args: tuple) -> dict:
 
 
 def _single_methods_for(eval_type: str) -> list[str]:
-    return [_SINGLE_METHOD_BOOTSTRAP_T] + ([_SINGLE_METHOD_WILSON] if eval_type == "binary" else [])
+    # Removed 2026-08-07: _SINGLE_METHOD_BOOTSTRAP_T is no longer part of
+    # the official set (matches pvalues.py's synthetic ppi official test,
+    # which validates the curated 4-method PPI-corrected CI comparison --
+    # Tango, Wilson, logit-t, t-interval -- not the bootstrap-based
+    # alternatives; see _PPI_CI_COMPARISON_TESTS). PPI_LOGIT_T is
+    # PPI_AUTO_METHOD_TABLE's "bounded_01" robustness method (every real
+    # dataset here is already rescaled to [0, 1] -- see
+    # RealJudgeBiasCorpus), the non-binary counterpart to Wilson's binary
+    # role. _ppi_single_bootstrap_t/_SINGLE_METHOD_BOOTSTRAP_T remain fully
+    # implemented and runnable via _run_real_single_cell for anyone who
+    # wants them back -- only the official roster changed.
+    return [_SINGLE_METHOD_WILSON] if eval_type == "binary" else [PPI_LOGIT_T.name]
 
 
 def _twogroup_methods_for(eval_type: str) -> list[str]:
@@ -946,12 +1023,21 @@ def _has_nonstandard_test(results: list) -> bool:
 
 
 def _paired_methods_for(eval_type: str) -> list[str]:
-    # Same _PPI_BINARY_COMPATIBLE_TESTS restriction, intersected with the
-    # paired-samples family: {ttest, ttest_welch, paired_t, bayes_bootstrap,
-    # tango} ∩ {wilcoxon, paired_t, bayes_bootstrap, bootstrap_t, tango}.
+    # BAYES_BOOTSTRAP/BOOTSTRAP_T removed 2026-08-07 (no longer part of the
+    # official CI-comparison set -- see _single_methods_for's matching
+    # note). Binary keeps TANGO (PPI_AUTO_METHOD_TABLE's binary pairwise
+    # method); non-binary gets PPI_T_INTERVAL and PPI_LOGIT_T
+    # (PPI_AUTO_METHOD_TABLE's "unbounded"/"bounded_01" pairwise methods --
+    # both tested, not just the "correct" one per data_kind, since this is
+    # a validation comparison, not production auto-routing -- matching
+    # pvalues.py's own _PPI_CI_COMPARISON_TESTS convention). This function
+    # feeds count-based (PPIResult-style) results only, never
+    # PPIEffectResult tuples, so unlike _WMT_PAIRED_BIAS_METHODS there is
+    # no test-name-collision risk between PPI_LOGIT_T here and the
+    # single-sample check's own PPI_LOGIT_T branch.
     if eval_type == "binary":
-        return [PAIRED_T.name, BAYES_BOOTSTRAP.name, TANGO.name]
-    return [WILCOXON.name, PAIRED_T.name, BAYES_BOOTSTRAP.name, BOOTSTRAP_T.name]
+        return [PAIRED_T.name, TANGO.name]
+    return [WILCOXON.name, PAIRED_T.name, PPI_T_INTERVAL.name, PPI_LOGIT_T.name]
 
 
 def _omnibus_independent_methods_for(eval_type: str) -> list[str]:

--- a/simulations/harness/cases/ppi_real.py
+++ b/simulations/harness/cases/ppi_real.py
@@ -161,6 +161,7 @@ with warnings.catch_warnings():
         _ppi_single_bootstrap_t,
         _ppi_single_wilson,
         _ppi_single_logit_t,
+        _ppi_single_t_interval,
         _ppi_two_sample,
         _ppi_two_sample_midrank_corrected,
         _ppi_two_sample_adaptive,
@@ -181,7 +182,7 @@ with warnings.catch_warnings():
 
 from ..methods import (
     TTEST, TTEST_WELCH, MWU, MWU_MNAR_EXPERIMENTAL, MWU_ADAPTIVE, MWU_RIDGE, WILCOXON, PAIRED_T, BAYES_BOOTSTRAP, BOOTSTRAP_T, TANGO,
-    PPI_T_INTERVAL, PPI_LOGIT_T,
+    PPI_T_INTERVAL, PPI_LOGIT_T, PPI_T_INTERVAL_SINGLE, PPI_LOGIT_T_SINGLE,
     ANOVA_IND, ANOVA_REP, FRIEDMAN, KRUSKAL, PPI_TEST_METHODS, get_method_color,
 )
 from ..scenarios.real_judge_bias import (
@@ -276,14 +277,33 @@ def _run_real_single_cell(
                 except Exception:
                     pass
 
-            if PPI_LOGIT_T.name in methods:
+            if PPI_LOGIT_T_SINGLE.name in methods:
                 try:
                     # Closed-form logit-t, PPI_AUTO_METHOD_TABLE's "bounded_01"
                     # robustness method (both judge and human are already
                     # rescaled to [0, 1] -- see RealJudgeBiasCorpus) -- the
                     # non-binary counterpart to the Wilson branch above.
+                    # PPI_LOGIT_T_SINGLE, NOT PPI_LOGIT_T -- this is a
+                    # single-sample mean estimand, a different quantity from
+                    # PPI_LOGIT_T's PAIRED mean-difference role in
+                    # _run_real_paired_cell/_run_real_wmt_paired_bias_cell;
+                    # using the same test name here would silently pool two
+                    # different estimands' bias/coverage stats together in
+                    # print_ppi_effect_report (name-only pooling) -- see
+                    # PPI_T_INTERVAL_SINGLE/PPI_LOGIT_T_SINGLE's docstrings.
                     r = _ppi_single_logit_t(judge, lab, _ALPHA)
-                    out[PPI_LOGIT_T.name].append((r.estimate, r.ci_low, r.ci_high, r.llm_estimate))
+                    out[PPI_LOGIT_T_SINGLE.name].append((r.estimate, r.ci_low, r.ci_high, r.llm_estimate))
+                except Exception:
+                    pass
+
+            if PPI_T_INTERVAL_SINGLE.name in methods:
+                try:
+                    # Closed-form t-interval, PPI_AUTO_METHOD_TABLE's
+                    # "unbounded" robustness method -- see PPI_LOGIT_T_SINGLE
+                    # branch above for the naming-collision reasoning
+                    # (same applies here vs. paired PPI_T_INTERVAL).
+                    r = _ppi_single_t_interval(judge, lab, _ALPHA)
+                    out[PPI_T_INTERVAL_SINGLE.name].append((r.estimate, r.ci_low, r.ci_high, r.llm_estimate))
                 except Exception:
                     pass
 
@@ -787,21 +807,19 @@ def _run_real_wmt_paired_power_cell(
     return corrected, uncorrected
 
 
-_WMT_PAIRED_BIAS_METHODS = [WILCOXON.name, PAIRED_T.name, PPI_T_INTERVAL.name]
+_WMT_PAIRED_BIAS_METHODS = [WILCOXON.name, PAIRED_T.name, PPI_T_INTERVAL.name, PPI_LOGIT_T.name]
 """_paired_methods_for("continuous") minus BAYES_BOOTSTRAP/BOOTSTRAP_T
 (removed 2026-08-07, no longer part of ppi_real's official CI-comparison
-set -- see _paired_methods_for) and minus PPI_LOGIT_T specifically: its
-test name ("ppi_logit_t") would be IDENTICAL to the single-sample bias/
-coverage check's own PPI_LOGIT_T branch, which targets a totally
-different estimand (a population MEAN, not a population MEAN PAIRED
-DIFFERENCE). print_ppi_effect_report pools rows by test name only (not
-tag), so including it here would silently merge two unrelated checks'
-bias/coverage stats into one misleading "ppi_logit_t" row -- the same
-collision problem BOOTSTRAP_T used to create here, just with a new name
-now that BOOTSTRAP_T itself is gone from the official set. PPI_T_INTERVAL
-has no such collision (nothing else in the official set uses it for a
-different estimand), so it's safe to include. TANGO excluded for the
-same eval_type restriction _paired_methods_for applies (this corpus is
+set -- see _paired_methods_for). PPI_T_INTERVAL/PPI_LOGIT_T are both safe
+to include here as of 2026-08-07: the single-sample bias/coverage check
+now uses the distinct PPI_T_INTERVAL_SINGLE/PPI_LOGIT_T_SINGLE Method
+identities (split from these paired ones in methods.py, the same way
+PPI_BOOTSTRAP_T_SINGLE is split from BOOTSTRAP_T) instead of reusing these
+paired ones, so there's no more test-name collision in
+print_ppi_effect_report's by-test-name pooling -- see PPI_T_INTERVAL_
+SINGLE/PPI_LOGIT_T_SINGLE's docstrings for the full reasoning (this is the
+same collision class BOOTSTRAP_T used to create here). TANGO excluded for
+the same eval_type restriction _paired_methods_for applies (this corpus is
 always eval_type="continuous_paired")."""
 
 _WMT_PAIRED_POWER_METHODS = [WILCOXON.name, PAIRED_T.name, PPI_T_INTERVAL.name, PPI_LOGIT_T.name]
@@ -881,13 +899,25 @@ def _run_real_wmt_paired_bias_cell(
                 except Exception:
                     pass
 
-            # BOOTSTRAP_T and PPI_LOGIT_T deliberately NOT included here --
-            # see _WMT_PAIRED_BIAS_METHODS' docstring (both would collide by
-            # test name with the single-sample check's own branches, which
-            # target a totally different estimand, and print_ppi_effect_
-            # report pools by test name only). Not wired up at all, rather
-            # than left reachable-but-unused, since nothing calls this
-            # function with a methods list that would ever hit them.
+            if PPI_LOGIT_T.name in methods:
+                try:
+                    r = _ppi_paired_logit_t(llm_x, llm_y, lab_x, lab_y, _ALPHA)
+                    out[PPI_LOGIT_T.name].append((r.estimate, r.ci_low, r.ci_high, r.llm_estimate))
+                except Exception:
+                    pass
+
+            # BOOTSTRAP_T deliberately NOT included here -- see
+            # _WMT_PAIRED_BIAS_METHODS' docstring (its test name collides
+            # with the single-sample check's own bootstrap_t branch, which
+            # targets a totally different estimand, and print_ppi_effect_
+            # report pools by test name only). PPI_T_INTERVAL/PPI_LOGIT_T
+            # above are safe now that the single-sample check uses the
+            # distinct PPI_T_INTERVAL_SINGLE/PPI_LOGIT_T_SINGLE Method
+            # identities instead of reusing these paired ones (2026-08-07 --
+            # see those Methods' docstrings in methods.py). BOOTSTRAP_T is
+            # not wired up at all, rather than left reachable-but-unused,
+            # since nothing calls this function with a methods list that
+            # would ever hit it.
 
     return dict(out)
 
@@ -976,14 +1006,26 @@ def _single_methods_for(eval_type: str) -> list[str]:
     # the official set (matches pvalues.py's synthetic ppi official test,
     # which validates the curated 4-method PPI-corrected CI comparison --
     # Tango, Wilson, logit-t, t-interval -- not the bootstrap-based
-    # alternatives; see _PPI_CI_COMPARISON_TESTS). PPI_LOGIT_T is
-    # PPI_AUTO_METHOD_TABLE's "bounded_01" robustness method (every real
-    # dataset here is already rescaled to [0, 1] -- see
-    # RealJudgeBiasCorpus), the non-binary counterpart to Wilson's binary
-    # role. _ppi_single_bootstrap_t/_SINGLE_METHOD_BOOTSTRAP_T remain fully
+    # alternatives; see _PPI_CI_COMPARISON_TESTS). PPI_LOGIT_T_SINGLE/
+    # PPI_T_INTERVAL_SINGLE are PPI_AUTO_METHOD_TABLE's "bounded_01"/
+    # "unbounded" robustness methods (every real dataset here is already
+    # rescaled to [0, 1] -- see RealJudgeBiasCorpus -- so both apply, not
+    # just logit-t's "correct" bounded_01 pick; this is a validation
+    # comparison, not production auto-routing, same convention
+    # _paired_methods_for uses), the non-binary counterpart to Wilson's
+    # binary role. NOT PPI_LOGIT_T/PPI_T_INTERVAL (unsuffixed) -- those
+    # names are reserved for the PAIRED estimand elsewhere in this file
+    # (_paired_methods_for/_WMT_PAIRED_BIAS_METHODS/_WMT_PAIRED_POWER_
+    # METHODS); reusing them for this single-sample MEAN estimand would
+    # silently pool two different estimands' stats together in
+    # print_ppi_effect_report -- see PPI_T_INTERVAL_SINGLE/
+    # PPI_LOGIT_T_SINGLE's docstrings in methods.py.
+    # _ppi_single_bootstrap_t/_SINGLE_METHOD_BOOTSTRAP_T remain fully
     # implemented and runnable via _run_real_single_cell for anyone who
     # wants them back -- only the official roster changed.
-    return [_SINGLE_METHOD_WILSON] if eval_type == "binary" else [PPI_LOGIT_T.name]
+    if eval_type == "binary":
+        return [_SINGLE_METHOD_WILSON]
+    return [PPI_LOGIT_T_SINGLE.name, PPI_T_INTERVAL_SINGLE.name]
 
 
 def _twogroup_methods_for(eval_type: str) -> list[str]:

--- a/simulations/harness/cases/pvalues.py
+++ b/simulations/harness/cases/pvalues.py
@@ -8853,7 +8853,8 @@ def save_results_artifacts_ppi_effect(*, results: list[PPIEffectResult], alpha: 
 
 
 def save_ppi_effect_plot(
-    *, results: list[PPIEffectResult], alpha: float, out_path: str, ci_comparison: bool = False, regime: str = "",
+    *, results: list[PPIEffectResult], alpha: float, out_path: str, ci_comparison: bool = False,
+    nonstandard: bool = False, regime: str = "",
     width_norm: dict[str, float] | None = None,
 ) -> str:
     """Bias-z / CI-coverage / CI-width scatter, one jittered column per test
@@ -8870,6 +8871,19 @@ def save_ppi_effect_plot(
         PPI logit-t, PPI t-interval -- see _PPI_CI_COMPARISON_TESTS for
         why exactly these four (and not the broader bootstrap/CI-based
         set _ppi_tests_present(nonstandard=True) would return).
+
+    nonstandard : bool
+        Ignored when ci_comparison=True (that branch has its own fixed
+        4-method set). Otherwise, False (default) plots the standard/
+        textbook tests as above; True plots the complementary broader
+        bootstrap/CI-based set instead (_ppi_tests_present(nonstandard=
+        True) -- everything ci_comparison's curated 4 are a subset of).
+        Added 2026-08-07: this parameter existed in _ppi_tests_present
+        (the helper this function already calls) but was never actually
+        threaded through here -- ppi_real.py's official-test pathway
+        called save_ppi_effect_plot(..., nonstandard=True) assuming it
+        was, which raised TypeError (unexpected keyword argument) on
+        every --official-tests run that reached it.
 
     width_norm : dict[str, float] | None
         Optional ``{scenario_name: divisor}`` map (typically each
@@ -8901,7 +8915,7 @@ def save_ppi_effect_plot(
     if not results:
         raise ValueError("save_ppi_effect_plot: no PPI effect-check results to plot.")
 
-    tests = _ppi_ci_comparison_tests_present(results) if ci_comparison else _ppi_tests_present(results, nonstandard=False)
+    tests = _ppi_ci_comparison_tests_present(results) if ci_comparison else _ppi_tests_present(results, nonstandard=nonstandard)
     target_cov = 1.0 - alpha
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(16.0, 5.5))
     rng = np.random.default_rng(0)
@@ -8953,7 +8967,12 @@ def save_ppi_effect_plot(
     ax3.grid(axis="y", alpha=0.25, lw=0.8)
 
     handles, labels = ax1.get_legend_handles_labels()
-    title_suffix = " -- PPI-Corrected CI Methods (Tango / Wilson / Logit-t / t-interval)" if ci_comparison else ""
+    if ci_comparison:
+        title_suffix = " -- PPI-Corrected CI Methods (Tango / Wilson / Logit-t / t-interval)"
+    elif nonstandard:
+        title_suffix = " -- Nonstandard (Bootstrap/CI-Based) Tests"
+    else:
+        title_suffix = ""
     title_suffix += f" ({regime})" if regime else ""
     fig.suptitle(f"PPI-Corrected Effect-Size Calibration: Bias, Coverage, and Width{title_suffix}", fontsize=12)
     fig.legend(handles, labels, loc="center left", bbox_to_anchor=(1.0, 0.5), fontsize=8, borderaxespad=0.5)

--- a/simulations/harness/cases/pvalues.py
+++ b/simulations/harness/cases/pvalues.py
@@ -271,6 +271,8 @@ from ..methods import (
     PPI_BOOTSTRAP_T_SINGLE,
     PPI_T_INTERVAL,
     PPI_LOGIT_T,
+    PPI_T_INTERVAL_SINGLE,
+    PPI_LOGIT_T_SINGLE,
     TTEST,
     TTEST_WELCH,
     MWU,
@@ -3899,6 +3901,7 @@ _PPI_EFFECT_TESTS = (
 _PPI_NONSTANDARD_TESTS = {
     BAYES_BOOTSTRAP.name, BOOTSTRAP_T.name, TANGO.name, PPI_WILSON.name,
     PPI_BOOTSTRAP_T_SINGLE.name, PPI_T_INTERVAL.name, PPI_LOGIT_T.name,
+    PPI_T_INTERVAL_SINGLE.name, PPI_LOGIT_T_SINGLE.name,
 }
 
 _PPI_CI_COMPARISON_TESTS = {TANGO.name, PPI_WILSON.name, PPI_LOGIT_T.name, PPI_T_INTERVAL.name}
@@ -7935,6 +7938,7 @@ _PPI_PRETTY_TEST_NAMES: dict[str, str] = {
     LMM.name: "LMM", LMM_FACTORIAL.name: "LMM (factorial)", LMM_RUNS.name: "LMM (nested runs)",
     PPI_T_INTERVAL.name: "t-interval", PPI_LOGIT_T.name: "logit-t",
     PPI_WILSON.name: "Wilson", PPI_BOOTSTRAP_T_SINGLE.name: "Bootstrap-t (single)",
+    PPI_T_INTERVAL_SINGLE.name: "t-interval (single)", PPI_LOGIT_T_SINGLE.name: "logit-t (single)",
 }
 
 

--- a/simulations/harness/methods.py
+++ b/simulations/harness/methods.py
@@ -113,35 +113,59 @@ BOOTSTRAP_T (the paired/two-sample PPI method of the same underlying
 construction) -- same reason PPI_WILSON isn't named "wilson": different
 estimand, would silently collide if given the same Method name."""
 PPI_T_INTERVAL = Method("ppi_t_interval", "#08519c")
-"""PPI-corrected single-/paired-sample closed-form (no-bootstrap) t-interval
-for an UNBOUNDED numeric mean/mean-difference estimand (evalstats.tests.
-_ppi_single_t_interval / _ppi_paired_t_interval, both thin wrappers around
-evalstats.ppi._analytic_mean_correct). The closed-form replacement for
-BOOTSTRAP_T's role in PPI_AUTO_METHOD_TABLE's "unbounded" row (see
-evalstats.config) -- resolved 2026-08-05, closing a previously-documented
-gap. Uses the analytic construction at EVERY n_lab, not just below
-_MIN_LAB_RECOMMENDED, mirroring the precedent evalstats.ppi.
-_ANALYTIC_ALWAYS_PREFERRED set for the Wilcoxon estimand (analytic beat
-bootstrap at every n_lab tested, 30-200). Run as a PAIRED mean-difference
-test in this harness (cell.llm_x/llm_y/lab_x/lab_y), the same structural
-role BOOTSTRAP_T/PAIRED_T occupy -- see PPI_LOGIT_T below for its
-[0,1]-bounded sibling. Deliberately NOT named "t_interval" -- that's
-already the plain (non-PPI-corrected) classical T_INTERVAL method above,
-a different statistical procedure that happens to share the textbook
-name (same reason PPI_WILSON isn't named "wilson")."""
+"""PPI-corrected closed-form (no-bootstrap) t-interval for an UNBOUNDED
+numeric mean/mean-difference estimand (evalstats.tests._ppi_single_t_interval
+/ _ppi_paired_t_interval, both thin wrappers around evalstats.ppi.
+_analytic_mean_correct). The closed-form replacement for BOOTSTRAP_T's role
+in PPI_AUTO_METHOD_TABLE's "unbounded" row (see evalstats.config) --
+resolved 2026-08-05, closing a previously-documented gap. Uses the analytic
+construction at EVERY n_lab, not just below _MIN_LAB_RECOMMENDED,
+mirroring the precedent evalstats.ppi._ANALYTIC_ALWAYS_PREFERRED set for
+the Wilcoxon estimand (analytic beat bootstrap at every n_lab tested,
+30-200). Run as a PAIRED mean-difference test in this harness (cell.llm_x/
+llm_y/lab_x/lab_y), the same structural role BOOTSTRAP_T/PAIRED_T occupy --
+see PPI_LOGIT_T below for its [0,1]-bounded sibling. Deliberately NOT named
+"t_interval" -- that's already the plain (non-PPI-corrected) classical
+T_INTERVAL method above, a different statistical procedure that happens to
+share the textbook name (same reason PPI_WILSON isn't named "wilson").
+
+PAIRED estimand only, as of ppi_real.py's real-data check gaining a
+single-sample robustness-CI check that ALSO wants closed-form t-interval/
+logit-t coverage (2026-08-07) -- see PPI_T_INTERVAL_SINGLE below for the
+single-sample sibling, split out the same way PPI_BOOTSTRAP_T_SINGLE was
+split from BOOTSTRAP_T: this Method's name is pooled across every paired-
+family check that uses it (print_ppi_effect_report groups by test name
+only, not by estimand), so a single-sample usage under the SAME name would
+silently merge two different estimands' bias/coverage stats together."""
+PPI_T_INTERVAL_SINGLE = Method("ppi_t_interval_single", "#6baed6")  # lighter tint of PPI_T_INTERVAL
+"""Single-sample sibling of PPI_T_INTERVAL (evalstats.tests.
+_ppi_single_t_interval), split out 2026-08-07 for the same reason
+PPI_BOOTSTRAP_T_SINGLE is split from BOOTSTRAP_T -- see PPI_T_INTERVAL's
+docstring. Targets an UNBOUNDED numeric single-sample mean estimand, the
+non-binary/non-[0,1]-bounded counterpart to PPI_WILSON's role."""
 PPI_LOGIT_T = Method("ppi_logit_t", "#8dd3c7")
-"""PPI-corrected single-/paired-sample closed-form (no-bootstrap) logit-t
-CI for a [lo, hi]-BOUNDED numeric mean/mean-difference estimand
-(evalstats.tests._ppi_single_logit_t / _ppi_paired_logit_t, wrapping
-evalstats.ppi._analytic_logit_t_correct -- the PPI analogue of
-evalstats.core.resampling.logit_t_ci_1d's delta-method construction,
+"""PPI-corrected closed-form (no-bootstrap) logit-t CI for a [lo, hi]-BOUNDED
+numeric mean/mean-difference estimand (evalstats.tests._ppi_single_logit_t /
+_ppi_paired_logit_t, wrapping evalstats.ppi._analytic_logit_t_correct -- the
+PPI analogue of evalstats.core.resampling.logit_t_ci_1d's delta-method construction,
 reusing the SAME point estimate/p-value as PPI_T_INTERVAL and differing
 only in the CI's shape). The closed-form replacement for BOOTSTRAP_T's
 role in PPI_AUTO_METHOD_TABLE's "bounded_01" row -- resolved 2026-08-05.
 Run as a PAIRED mean-difference test here, rescaled onto [0, 1] via this
 harness's own EVAL_TYPE_SCALE_BOUNDS[eval_type] (continuous/likert/grades;
 excluded from binary scenarios the same way BOOTSTRAP_T is). Deliberately
-NOT named "logit_t" -- see PPI_T_INTERVAL's docstring for why."""
+NOT named "logit_t" -- see PPI_T_INTERVAL's docstring for why.
+
+PAIRED estimand only -- see PPI_LOGIT_T_SINGLE below and PPI_T_INTERVAL's
+matching docstring addendum for why (same name-pooling collision risk)."""
+PPI_LOGIT_T_SINGLE = Method("ppi_logit_t_single", "#ccebc5")  # lighter tint of PPI_LOGIT_T
+"""Single-sample sibling of PPI_LOGIT_T (evalstats.tests._ppi_single_logit_t),
+split out 2026-08-07 for the same reason PPI_BOOTSTRAP_T_SINGLE is split
+from BOOTSTRAP_T -- see PPI_T_INTERVAL_SINGLE's docstring (identical
+reasoning, [0,1]-bounded instead of unbounded). PPI_AUTO_METHOD_TABLE's
+"bounded_01" robustness method -- the non-binary counterpart to PPI_WILSON's
+binary role; every real dataset ppi_real.py checks is already rescaled to
+[0, 1] (see RealJudgeBiasCorpus), so this applies uniformly there."""
 TANGO_SCC = Method("tango_scc", "#b15928")
 BAYES_PAIR_INDEP = Method("bayes_indep_comp", "#ffbb78")
 BAYES_PAIR_PAIRED = Method("bayes_paired_comp", "#98df8a")
@@ -566,7 +590,7 @@ LMM_RUNS = Method("lmm_runs", "#c7e9c0")
 PPI_TEST_METHODS = [
     TTEST, TTEST_WELCH, MWU, MWU_MNAR_EXPERIMENTAL, MWU_MNAR_POOLED, MWU_ADAPTIVE, MWU_RIDGE, WILCOXON, PAIRED_T, BAYES_BOOTSTRAP, BOOTSTRAP_T, TANGO, ANOVA_IND,
     ANOVA_REP, FRIEDMAN, KRUSKAL, KRUSKAL_MNAR_EXPERIMENTAL, LMM, LMM_FACTORIAL, LMM_RUNS, PPI_WILSON,
-    PPI_BOOTSTRAP_T_SINGLE, PPI_T_INTERVAL, PPI_LOGIT_T,
+    PPI_BOOTSTRAP_T_SINGLE, PPI_T_INTERVAL, PPI_LOGIT_T, PPI_T_INTERVAL_SINGLE, PPI_LOGIT_T_SINGLE,
 ]
 """Every PPI test method the harness knows how to run -- the full set
 selectable via --tests. NOT what runs by default; see
@@ -612,7 +636,7 @@ REPORT_METHOD_ORDER: list[Method] = BOOTSTRAP_METHODS + [
     + [TANGO_FLAT, NEWCOMBE_FLAT] + BINARY_PAIR_NESTED_METHODS
 ) + [
     MCNEMAR, PERMUTATION, SIGN_TEST, NEWCOMBE_PVAL, BAYES_BINARY, WILCOXON, PAIRED_T, PPI_T_INTERVAL, PPI_LOGIT_T,
-    PPI_WILSON, PPI_BOOTSTRAP_T_SINGLE,
+    PPI_WILSON, PPI_BOOTSTRAP_T_SINGLE, PPI_T_INTERVAL_SINGLE, PPI_LOGIT_T_SINGLE,
 ] + MULTIARM_CORRECTION_METHODS + CANONICAL_SIMULTANEOUS_CI_METHODS + [
     TTEST, TTEST_WELCH, MWU, MWU_MNAR_EXPERIMENTAL, MWU_MNAR_POOLED, MWU_ADAPTIVE, MWU_RIDGE, ANOVA_IND, ANOVA_REP, FRIEDMAN, KRUSKAL, KRUSKAL_MNAR_EXPERIMENTAL,
     LMM, LMM_FACTORIAL, LMM_RUNS,

--- a/tests/test_p_values.py
+++ b/tests/test_p_values.py
@@ -132,9 +132,11 @@ class TestAnalyzeStoresPValueMethod:
         bundle = self._bundle()
         assert bundle.p_value_method is None
 
-    def test_p_values_true_stores_auto(self):
+    def test_p_values_true_stores_wsr_for_k2(self):
+        """k=2 is a single pairwise comparison (fig:fwer-decision-tree):
+        auto always resolves to Wilcoxon signed-ranks, unconditionally."""
         bundle = self._bundle(p_values=True)
-        assert bundle.p_value_method == "auto"
+        assert bundle.p_value_method == "wsr"
 
     def test_p_values_true_omnibus_stores_wsr(self):
         bundle = self._bundle(p_values=True, omnibus=True)
@@ -180,11 +182,13 @@ class TestComparePropagatesPValueMethod:
         report = es.compare_prompts(_scores_2prompt(), n_bootstrap=200, rng=_rng())
         assert report.p_value_method is None
 
-    def test_p_values_true_report_stores_auto(self):
+    def test_p_values_true_report_stores_wsr_for_k2(self):
+        """k=2 is a single pairwise comparison (fig:fwer-decision-tree):
+        auto always resolves to Wilcoxon signed-ranks, unconditionally."""
         report = es.compare_prompts(
             _scores_2prompt(), n_bootstrap=200, rng=_rng(), p_values=True
         )
-        assert report.p_value_method == "auto"
+        assert report.p_value_method == "wsr"
 
     @pytest.mark.parametrize("test,expected", [
         ("bootstrap", "boot"),
@@ -198,12 +202,13 @@ class TestComparePropagatesPValueMethod:
         assert report.p_value_method == expected
 
     def test_compare_models_propagates(self):
+        """k=2 models -> single pairwise comparison -> Wilcoxon, unconditionally."""
         scores = {
             "M1": _scores_2prompt(n=40, seed=0)["A"],
             "M2": _scores_2prompt(n=40, seed=1)["B"],
         }
         report = es.compare_models(scores, n_bootstrap=200, rng=_rng(), p_values=True)
-        assert report.p_value_method == "auto"
+        assert report.p_value_method == "wsr"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_p_values.py
+++ b/tests/test_p_values.py
@@ -82,31 +82,29 @@ def _make_benchmark(scores_dict: dict) -> BenchmarkResult:
 
 class TestResolvePValueMethod:
     def test_default_suppresses(self):
-        assert _resolve_p_value_method(False, "auto", False) is None
+        assert _resolve_p_value_method(False, "auto") is None
 
-    def test_p_values_true_no_omnibus_returns_auto(self):
-        assert _resolve_p_value_method(True, "auto", False) == "auto"
-
-    def test_p_values_true_omnibus_returns_wsr(self):
-        # Wilcoxon is the standard Friedman post-hoc.
-        assert _resolve_p_value_method(True, "auto", True) == "wsr"
+    def test_p_values_true_returns_auto_sentinel(self):
+        # Final resolution (Wilcoxon by default, or Romano-Wolf's own
+        # p-value when that's the fired FWER correction) happens at print
+        # time in core.summary, since it depends on which correction
+        # actually resolved for this bundle -- not known until
+        # all_pairwise() has run. See TestAutoPValueColumnResolution below
+        # for that resolution logic.
+        assert _resolve_p_value_method(True, "auto") == "auto"
 
     def test_explicit_bootstrap_enables_without_flag(self):
-        assert _resolve_p_value_method(False, "bootstrap", False) == "boot"
+        assert _resolve_p_value_method(False, "bootstrap") == "boot"
 
     def test_explicit_wilcoxon_enables_without_flag(self):
-        assert _resolve_p_value_method(False, "wilcoxon", False) == "wsr"
+        assert _resolve_p_value_method(False, "wilcoxon") == "wsr"
 
     def test_explicit_nemenyi_enables_without_flag(self):
-        assert _resolve_p_value_method(False, "nemenyi", False) == "nem"
+        assert _resolve_p_value_method(False, "nemenyi") == "nem"
 
     def test_explicit_wilcoxon_overrides_bootstrap_path(self):
         # Explicitly choosing wilcoxon should work even when using bootstrap CIs.
-        assert _resolve_p_value_method(True, "wilcoxon", False) == "wsr"
-
-    def test_explicit_bootstrap_overrides_omnibus(self):
-        # Explicit pairwise_test wins over omnibus-driven auto selection.
-        assert _resolve_p_value_method(True, "bootstrap", True) == "boot"
+        assert _resolve_p_value_method(True, "wilcoxon") == "wsr"
 
     @pytest.mark.parametrize("test,expected", [
         ("bootstrap", "boot"),
@@ -114,7 +112,7 @@ class TestResolvePValueMethod:
         ("nemenyi", "nem"),
     ])
     def test_explicit_tests_map_correctly(self, test, expected):
-        assert _resolve_p_value_method(True, test, False) == expected
+        assert _resolve_p_value_method(True, test) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -132,15 +130,17 @@ class TestAnalyzeStoresPValueMethod:
         bundle = self._bundle()
         assert bundle.p_value_method is None
 
-    def test_p_values_true_stores_wsr_for_k2(self):
-        """k=2 is a single pairwise comparison (fig:fwer-decision-tree):
-        auto always resolves to Wilcoxon signed-ranks, unconditionally."""
+    def test_p_values_true_stores_auto(self):
+        """Stores the 'auto' sentinel -- final resolution (Wilcoxon by
+        default, or Romano-Wolf's own p-value when that's the fired FWER
+        correction) happens at print time, not storage time, since it
+        depends on which correction actually resolved for this bundle."""
         bundle = self._bundle(p_values=True)
-        assert bundle.p_value_method == "wsr"
+        assert bundle.p_value_method == "auto"
 
-    def test_p_values_true_omnibus_stores_wsr(self):
+    def test_p_values_true_omnibus_stores_auto(self):
         bundle = self._bundle(p_values=True, omnibus=True)
-        assert bundle.p_value_method == "wsr"
+        assert bundle.p_value_method == "auto"
 
     @pytest.mark.parametrize("test,expected", [
         ("bootstrap", "boot"),
@@ -182,13 +182,13 @@ class TestComparePropagatesPValueMethod:
         report = es.compare_prompts(_scores_2prompt(), n_bootstrap=200, rng=_rng())
         assert report.p_value_method is None
 
-    def test_p_values_true_report_stores_wsr_for_k2(self):
-        """k=2 is a single pairwise comparison (fig:fwer-decision-tree):
-        auto always resolves to Wilcoxon signed-ranks, unconditionally."""
+    def test_p_values_true_report_stores_auto(self):
+        """Stores the 'auto' sentinel -- resolved to Wilcoxon (or
+        Romano-Wolf's own p-value) at print time, see TestAutoPValueColumnResolution."""
         report = es.compare_prompts(
             _scores_2prompt(), n_bootstrap=200, rng=_rng(), p_values=True
         )
-        assert report.p_value_method == "wsr"
+        assert report.p_value_method == "auto"
 
     @pytest.mark.parametrize("test,expected", [
         ("bootstrap", "boot"),
@@ -202,13 +202,12 @@ class TestComparePropagatesPValueMethod:
         assert report.p_value_method == expected
 
     def test_compare_models_propagates(self):
-        """k=2 models -> single pairwise comparison -> Wilcoxon, unconditionally."""
         scores = {
             "M1": _scores_2prompt(n=40, seed=0)["A"],
             "M2": _scores_2prompt(n=40, seed=1)["B"],
         }
         report = es.compare_models(scores, n_bootstrap=200, rng=_rng(), p_values=True)
-        assert report.p_value_method == "wsr"
+        assert report.p_value_method == "auto"
 
 
 # ---------------------------------------------------------------------------
@@ -248,10 +247,37 @@ class TestPrintAnalysisSummaryOutput:
         out = self._run_analyze(pairwise_test="nemenyi")
         assert "p (nem)" in out
 
-    def test_p_values_true_omnibus_shows_wsr(self):
-        # With omnibus=True, auto resolves to wsr.
+    def test_p_values_true_omnibus_shows_rw_at_n_ge_30(self):
+        # _scores_3prompt defaults to N=40 (bounded_01) -> Romano-Wolf is the
+        # resolved FWER correction, which has no Wilcoxon-compatible joint
+        # construction, so its own p-value is shown instead of wsr.
         out = self._run_analyze(p_values=True, omnibus=True)
+        assert "p (RW)" in out
+        assert "p (wsr)" not in out
+
+    def test_p_values_true_shows_wsr_at_n_lt_30(self):
+        # N=20 -> Shaffer's is the resolved correction, which does apply to
+        # Wilcoxon's own p-value -- so wsr stays the default here.
+        bench = _make_benchmark(_scores_3prompt(n=20))
+        bundle = es.analyze(bench, n_bootstrap=300, rng=_rng(), p_values=True)
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            es.print_analysis_summary(bundle)
+        out = buf.getvalue()
         assert "p (wsr)" in out
+        assert "p (RW)" not in out
+
+    def test_explicit_wilcoxon_stays_wsr_even_at_n_ge_30(self):
+        # An explicit pairwise_test="wilcoxon" request is never silently
+        # swapped for Romano-Wolf's different (non-Wilcoxon) statistic --
+        # it keeps Wilcoxon's own p-value, corrected via Shaffer's (the only
+        # valid correction for that statistic at any N, since Romano-Wolf
+        # has no Wilcoxon-compatible form).
+        out = self._run_analyze(pairwise_test="wilcoxon")
+        assert "p (wsr)" in out
+        assert "p (RW)" not in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_simultaneous_ci.py
+++ b/tests/test_simultaneous_ci.py
@@ -436,23 +436,25 @@ def test_all_pairwise_simultaneous_ci_true_by_default():
 
 
 def test_all_pairwise_test_method_string_annotated():
-    """PairwiseMatrix.simultaneous_ci_method should record the variant used
-    ('bonferroni' by default, even for bootstrap methods); the CI annotation
-    is no longer baked into each PairedDiffResult.test_method."""
+    """PairwiseMatrix.simultaneous_ci_method should record the variant used;
+    the CI annotation is no longer baked into each PairedDiffResult.test_method.
+    Explicitly requests prefer="bonferroni" -- fig:fwer-decision-tree's
+    auto default no longer picks Bonferroni (see test_router_returns_boot_
+    by_default_for_bootstrap for that)."""
     scores = _rng(11).normal(0, 1, (3, 30))
     labels = ["a", "b", "c"]
 
     mat = all_pairwise(
         scores, labels, method="bootstrap", ci=0.95,
         n_bootstrap=200, correction="none", rng=_rng(11),
-        simultaneous_ci=True,
+        simultaneous_ci=True, prefer="bonferroni",
     )
 
     assert mat.simultaneous_ci_method == "bonferroni"
 
 
 def test_all_pairwise_p_values_valid_with_simultaneous_ci_bonferroni():
-    """When simultaneous_ci=True (the default construction is now Bonferroni),
+    """When simultaneous_ci=True with prefer="bonferroni" explicitly requested,
     p_value stays the original marginal p-value — Bonferroni here only adjusts
     the CI bounds, not the p-values — and must still be a valid probability.
     """
@@ -462,7 +464,7 @@ def test_all_pairwise_p_values_valid_with_simultaneous_ci_bonferroni():
     mat_sim = all_pairwise(
         scores, labels, method="bootstrap", ci=0.95,
         n_bootstrap=300, correction="holm", rng=_rng(12),
-        simultaneous_ci=True,
+        simultaneous_ci=True, prefer="bonferroni",
     )
 
     assert mat_sim.simultaneous_ci_method == "bonferroni"
@@ -511,10 +513,14 @@ def test_compare_models_simultaneous_ci_propagates():
     assert report.simultaneous_ci is True
 
 
-def test_unsupported_method_falls_back_to_bonferroni():
-    """When method='newcombe' (no bootstrap CIs), simultaneous_ci=True should
-    fall back to Bonferroni t-intervals rather than silently ignoring the flag.
-    The report should have simultaneous_ci=True and method='bonferroni'."""
+def test_newcombe_uses_auto_simultaneous_ci_default():
+    """method='newcombe' has no bootstrap CIs, but Sidak/joint-bootstrap
+    simultaneous CIs are ci_func-based, not tied to whether the point-
+    estimate method is bootstrap-compatible -- so the "auto" default
+    (fig:fwer-decision-tree) applies normally here rather than falling back
+    to Bonferroni. That max-T-specific fallback for non-bootstrap methods is
+    still real and covered by test_router_falls_back_to_bonferroni_for_newcombe
+    (prefer="max_t")."""
     rng = _rng(40)
     scores = {
         "A": [int(x > 0.5) for x in rng.random(50)],
@@ -526,7 +532,8 @@ def test_unsupported_method_falls_back_to_bonferroni():
         rng=_rng(40), n_bootstrap=200,
     )
     assert report.simultaneous_ci is True
-    assert report.pairwise.simultaneous_ci_method == "bonferroni"
+    # binary, N=50 -> "boot" row of AUTO_SIMULTANEOUS_CI_METHOD_TABLE
+    assert report.pairwise.simultaneous_ci_method == "boot"
 
 
 def test_seeded_compare_prompts_simultaneous_ci():
@@ -541,8 +548,10 @@ def test_seeded_compare_prompts_simultaneous_ci():
         scores, simultaneous_ci=True, rng=_rng(50), n_bootstrap=300,
     )
     assert report.simultaneous_ci is True
-    # t_interval is analytical → falls back to Bonferroni simultaneous CIs
-    assert report.pairwise.simultaneous_ci_method in {"max_t", "bonferroni"}
+    # Any construction is acceptable here -- this test is about seeded (R>=3)
+    # data not crashing the simultaneous-CI pipeline, not about which
+    # specific auto-routed method fires for this N/data-kind.
+    assert report.pairwise.simultaneous_ci_method in {"sidak", "boot", "max_t", "bonferroni"}
     for a, b in [("A", "B"), ("A", "C"), ("B", "C")]:
         lo, hi = report.pairwise.get(a, b).ci_low, report.pairwise.get(a, b).ci_high
         assert lo <= hi and np.isfinite(lo) and np.isfinite(hi)
@@ -633,9 +642,10 @@ def test_bonferroni_degenerate_zero_variance():
 
 # --- Router tests ---
 
-def test_router_returns_bonferroni_by_default_for_bootstrap():
-    """Router should choose 'bonferroni' by default, even for a
-    bootstrap-compatible method (Bonferroni is the default construction)."""
+def test_router_returns_boot_by_default_for_unbounded_n_ge_30():
+    """Router's "auto" default (fig:fwer-decision-tree) picks the joint
+    bootstrap ("boot") for unbounded numeric data at N>=30, regardless of
+    whether the point-estimate method is bootstrap-compatible."""
     scores = _rng(70).normal(0, 1, (3, 40))
     labels = ["a", "b", "c"]
     results, pairs = _make_results(scores, labels)
@@ -643,6 +653,21 @@ def test_router_returns_bonferroni_by_default_for_bootstrap():
         scores, results, pairs, labels,
         method="bootstrap", ci=0.95, n_bootstrap=300,
         rng=_rng(70), statistic="mean",
+    )
+    assert used == "boot"
+    assert len(cis) == len(pairs)
+
+
+def test_router_returns_bonferroni_when_explicitly_preferred():
+    """prefer="bonferroni" still forces the closed-form fallback directly."""
+    scores = _rng(70).normal(0, 1, (3, 40))
+    labels = ["a", "b", "c"]
+    results, pairs = _make_results(scores, labels)
+    cis, used, _ = _simultaneous_cis_router(
+        scores, results, pairs, labels,
+        method="bootstrap", ci=0.95, n_bootstrap=300,
+        rng=_rng(70), statistic="mean",
+        prefer="bonferroni",
     )
     assert used == "bonferroni"
     assert len(cis) == len(pairs)
@@ -665,7 +690,10 @@ def test_router_returns_max_stat_for_bootstrap_when_preferred():
 
 
 def test_router_falls_back_to_bonferroni_for_newcombe():
-    """Router should fall back to 'bonferroni' for analytical methods."""
+    """Router should fall back to 'bonferroni' for analytical methods when
+    prefer="max_t" is requested (max_t needs a bootstrap distribution;
+    Sidak/boot -- the auto default -- are ci_func-based and don't need this
+    fallback at all, see test_router_returns_boot_by_default_for_unbounded_n_ge_30)."""
     # Use continuous scores but force method='newcombe' to trigger the fallback.
     scores = _rng(71).normal(0, 1, (3, 40))
     labels = ["a", "b", "c"]
@@ -674,6 +702,7 @@ def test_router_falls_back_to_bonferroni_for_newcombe():
         scores, results, pairs, labels,
         method="newcombe", ci=0.95, n_bootstrap=300,
         rng=_rng(71), statistic="mean",
+        prefer="max_t",
     )
     assert used == "bonferroni"
     assert len(cis) == len(pairs)
@@ -699,10 +728,11 @@ def test_router_max_stat_for_all_bootstrap_methods_when_preferred(method):
     assert used == "max_t", f"Expected max_t for method={method!r}, got {used!r}"
 
 
-def test_simultaneous_ci_method_field_bonferroni_for_bootstrap():
-    """PairwiseMatrix.simultaneous_ci_method is 'bonferroni' by default, even
-    for bootstrap methods, since all_pairwise has no public prefer='max_t'
-    knob and Bonferroni is now the default construction."""
+def test_simultaneous_ci_method_field_boot_for_bootstrap():
+    """PairwiseMatrix.simultaneous_ci_method follows the "auto" table by
+    default (fig:fwer-decision-tree) -- unbounded numeric, N=30 -> "boot".
+    Pass prefer="bonferroni"/"max_t" to all_pairwise() to force a specific
+    construction instead."""
     scores = _rng(80).normal(0, 1, (3, 30))
     labels = ["a", "b", "c"]
     mat = all_pairwise(
@@ -710,11 +740,13 @@ def test_simultaneous_ci_method_field_bonferroni_for_bootstrap():
         rng=_rng(80), simultaneous_ci=True, correction="none",
     )
     assert mat.simultaneous_ci is True
-    assert mat.simultaneous_ci_method == "bonferroni"
+    assert mat.simultaneous_ci_method == "boot"
 
 
-def test_simultaneous_ci_method_field_bonferroni():
-    """PairwiseMatrix.simultaneous_ci_method is 'bonferroni' for analytical methods."""
+def test_simultaneous_ci_method_field_sidak():
+    """PairwiseMatrix.simultaneous_ci_method is 'sidak' for binary data
+    below the N=50 auto-routing threshold, regardless of the point-estimate
+    method (Sidak is ci_func-based, not tied to bootstrap-compatibility)."""
     scores = (_rng(81).random((3, 40)) > 0.5).astype(float)
     labels = ["a", "b", "c"]
     mat = all_pairwise(
@@ -722,7 +754,7 @@ def test_simultaneous_ci_method_field_bonferroni():
         rng=_rng(81), simultaneous_ci=True, correction="none",
     )
     assert mat.simultaneous_ci is True
-    assert mat.simultaneous_ci_method == "bonferroni"
+    assert mat.simultaneous_ci_method == "sidak"
 
 
 def test_simultaneous_ci_method_field_none_when_not_requested():
@@ -735,12 +767,14 @@ def test_simultaneous_ci_method_field_none_when_not_requested():
 
 
 def test_bonferroni_annotation_in_test_method():
-    """PairwiseMatrix.simultaneous_ci_method should be 'bonferroni' for the fallback."""
+    """PairwiseMatrix.simultaneous_ci_method reflects the explicitly
+    requested construction when prefer="bonferroni" is passed."""
     scores = (_rng(83).random((3, 40)) > 0.5).astype(float)
     labels = ["a", "b", "c"]
     mat = all_pairwise(
         scores, labels, method="newcombe", n_bootstrap=200,
         rng=_rng(83), simultaneous_ci=True, correction="none",
+        prefer="bonferroni",
     )
     assert mat.simultaneous_ci_method == "bonferroni"
 


### PR DESCRIPTION
## Summary
- Fix a crash in multi-model `.summary()` (UnboundLocalError whenever show_rank_probabilities defaults False), replace the significance-naive "best pair by mean" heatmap marker with a statistically-tied-for-best group, and make `ttest`/`mannwhitney`/`wilcoxon` accept human labels positionally (`ttest(a, b, a_lab, b_lab, ...)`).
- Add public `ComparisonResult.cross_model`/`.best_pairs` accessors so the full cross-model comparison is reachable without touching a private attribute.
- Refresh evalstats' FWER-correction defaults (simultaneous CIs, p-value correction, and the displayed pairwise p-value) to match the paper's simulation-backed decision tree: Šidák/joint-bootstrap replace a hardcoded Bonferroni default that was never actually wired up despite being validated; Romano-Wolf step-down (ported from and verified bit-identical to the simulation harness) replaces a stale FDR-BH default at N>=30; Wilcoxon signed-ranks becomes the default shown pairwise test everywhere except when Romano-Wolf is what resolved (it has no Wilcoxon-compatible joint form).

## Test plan
- [x] Full test suite passes (1017 tests), including new/updated tests asserting the corrected defaults
- [x] Romano-Wolf port verified bit-identical to the simulation harness's validated reference on matched RNG seeds
- [x] Manually verified N=20 -> Wilcoxon+Shaffer's, N=40 -> Romano-Wolf end-to-end, including the printed summary output