### PR TITLE
Add uncertainty-aware Pareto-front support for secondary metrics

### DIFF
--- a/evalstats/api.py
+++ b/evalstats/api.py
@@ -68,6 +68,7 @@ class ComparisonResult:
         self._mmb_view = _mmb_view  # which MultiModelBundle view is primary
         self._min_meaningful_diff = min_meaningful_diff
         self._variance_components: Optional[dict] = None  # set by MC alignment loop
+        self._pareto: Optional[dict] = None  # set by _run_pareto_if_needed when secondary= is passed
         # Bootstrap P(Best)/E[Rank] output is opt-in, not opt-out: it reads as
         # a confident, almost authoritative verdict (e.g. "63.6% probability
         # of being best") even when the underlying CIs overlap heavily and the
@@ -134,6 +135,40 @@ class ComparisonResult:
             item_singular=item_singular,
             item_plural=item_plural,
         )
+        if self._pareto is not None:
+            self._print_pareto_summary(show_rank_probabilities=show_rank)
+
+    def _print_pareto_summary(self, *, show_rank_probabilities: bool) -> None:
+        secondary_col = self._pareto["secondary_metric"]
+        direction = self._pareto["direction"]
+        statuses = self._pareto["statuses"]
+        result = self._pareto["result"]
+
+        dir_label = "lower is better" if direction == "min" else "higher is better"
+        print()
+        print(f"--- Pareto Front ({self._metric} vs {secondary_col}, {dir_label}) ---")
+        label_w = max((len(lbl) for lbl in result.labels), default=6)
+        label_w = max(label_w, len("Entity"))
+        status_w = max(len("Ambiguous"), len("Dominated"), len("Frontier"))
+        header = f"  {'Entity':<{label_w}}  {'Status':<{status_w}}  Detail"
+        print(header)
+        print("  " + "-" * (len(header) - 2))
+        for label in result.labels:
+            st = statuses[label]
+            status_disp = st.status.capitalize()
+            if st.status == "dominated":
+                detail = f"by {', '.join(st.dominated_by)}"
+            elif st.status == "ambiguous":
+                detail = f"vs {', '.join(st.ambiguous_vs)} (not statistically confirmed)"
+            else:
+                detail = ""
+            print(f"  {label:<{label_w}}  {status_disp:<{status_w}}  {detail}")
+        print("  " + "-" * (len(header) - 2))
+        if show_rank_probabilities:
+            print("\n  P(Pareto-optimal):")
+            for label, p in zip(result.labels, result.p_frontier):
+                print(f"    {label:<{label_w}}  {p:>6.1%}")
+        print()
 
     def brief(self) -> None:
         """Print a compact one-line-per-entity summary."""
@@ -406,6 +441,44 @@ class ComparisonResult:
                     top_pairs.append((parts[0], parts[1]))
         return top_pairs or None
 
+    @property
+    def pareto_status(self) -> Optional[dict]:
+        """Per-entity three-state Pareto classification, or ``None``.
+
+        Populated only when ``compare(..., secondary=...)`` was passed.
+        Keys are entity labels, values are
+        :class:`~evalstats.core.pareto.ParetoStatus` (``.status`` is one of
+        ``"frontier"``, ``"dominated"``, ``"ambiguous"`` -- see that class's
+        docstring for what distinguishes them). This is the calibrated
+        default view: an entity is only ever reported ``"dominated"`` when
+        the joint bootstrap actually supports it (FWER-aware across its
+        possible dominators), not merely because its point estimate lost on
+        both axes -- that weaker case is ``"ambiguous"`` instead of a false
+        "dominates" call.
+        """
+        return self._pareto["statuses"] if self._pareto is not None else None
+
+    @property
+    def pareto_frontier_probability(self) -> Optional[dict]:
+        """Per-entity ``P(entity is Pareto-optimal)``, or ``None``.
+
+        Populated only when ``compare(..., secondary=...)`` was passed. Keys
+        are entity labels, values are the fraction of joint bootstrap
+        replicates in which that entity was non-dominated -- a continuous
+        probability, not the calibrated three-state label
+        :attr:`pareto_status` gives. Exists for the same reason
+        ``show_rank_probabilities``/P(Best) is opt-in rather than the
+        default view elsewhere in evalstats: a raw probability like "82%
+        Pareto-optimal" reads as more decisive than it is when the
+        underlying joint CIs actually overlap heavily. Prefer
+        :attr:`pareto_status` for reporting; use this for downstream
+        numeric work.
+        """
+        if self._pareto is None:
+            return None
+        result = self._pareto["result"]
+        return dict(zip(result.labels, result.p_frontier.tolist()))
+
     # ── data access ──────────────────────────────────────────────────────────
 
     def to_dict(self, *, show_rank_probabilities: Optional[bool] = None) -> dict:
@@ -488,6 +561,22 @@ class ComparisonResult:
         }
         if self._variance_components is not None:
             result["variance_components"] = self._variance_components
+        if self._pareto is not None:
+            pareto_entities: dict[str, dict] = {}
+            for label, st in self._pareto["statuses"].items():
+                entry: dict[str, Any] = {"status": st.status}
+                if st.dominated_by:
+                    entry["dominated_by"] = list(st.dominated_by)
+                if st.ambiguous_vs:
+                    entry["ambiguous_vs"] = list(st.ambiguous_vs)
+                if show_rank:
+                    entry["p_pareto_optimal"] = float(self.pareto_frontier_probability[label])
+                pareto_entities[str(label)] = entry
+            result["pareto"] = {
+                "secondary_metric": self._pareto["secondary_metric"],
+                "direction": self._pareto["direction"],
+                "entities": pareto_entities,
+            }
         return result
 
     def to_frame(self, *, show_rank_probabilities: Optional[bool] = None) -> dict[str, pd.DataFrame]:
@@ -545,6 +634,20 @@ class ComparisonResult:
                 row_pw["p_value"] = float(pair_result.p_value)
             pw_rows.append(row_pw)
         frames["pairwise"] = pd.DataFrame(pw_rows)
+
+        if self._pareto is not None:
+            pareto_rows: list[dict] = []
+            for label, st in self._pareto["statuses"].items():
+                row_p: dict[str, Any] = {
+                    "entity": str(label),
+                    "status": st.status,
+                    "dominated_by": ", ".join(st.dominated_by) or None,
+                    "ambiguous_vs": ", ".join(st.ambiguous_vs) or None,
+                }
+                if show_rank:
+                    row_p["p_pareto_optimal"] = float(self.pareto_frontier_probability[label])
+                pareto_rows.append(row_p)
+            frames["pareto"] = pd.DataFrame(pareto_rows)
 
         return frames
 
@@ -1587,6 +1690,132 @@ def _run_judge_alignment_if_needed(
     )
 
 
+def _run_pareto_if_needed(
+    cr: "ComparisonResult",
+    *,
+    secondary,
+    df: pd.DataFrame,
+    factor_col: str,
+    item_col: str,
+    alpha: float,
+    n_boot: int,
+    rng,
+) -> None:
+    """Run uncertainty-aware Pareto-front analysis and store it on *cr*, if
+    ``secondary=`` was passed.
+
+    Mirrors ``_run_judge_alignment_if_needed``'s validate-and-dispatch shape:
+    warns and no-ops on a malformed ``secondary=``, and is only supported for
+    a single-factor result (a plain ``AnalysisBundle`` -- multi-model and
+    factorial results are not yet supported, same restriction as
+    ``alignment=``).
+    """
+    if secondary is None:
+        return
+    if not isinstance(secondary, dict):
+        warnings.warn(
+            "secondary= must be a dict mapping a metric column name to "
+            "'min' or 'max', e.g. secondary={'latency_ms': 'min'}. "
+            "secondary= will be ignored.",
+            UserWarning,
+            stacklevel=4,
+        )
+        return
+    if len(secondary) != 1:
+        raise NotImplementedError(
+            f"secondary= currently supports exactly one secondary metric "
+            f"(bivariate Pareto fronts only); got {len(secondary)}: "
+            f"{list(secondary.keys())}. N-way Pareto fronts are not yet "
+            "implemented."
+        )
+    (secondary_col, direction), = secondary.items()
+    if direction not in ("min", "max"):
+        raise ValueError(
+            f"secondary={{'{secondary_col}': {direction!r}}} -- direction "
+            "must be 'min' or 'max'."
+        )
+    if secondary_col not in df.columns:
+        raise EvalLoadError(
+            f"secondary metric column '{secondary_col}' not found in data. "
+            f"Available columns: {list(df.columns)}"
+        )
+
+    if not isinstance(cr._analysis, AnalysisBundle):
+        # cr._primary_bundle() always unwraps a MultiModelBundle down to some
+        # single AnalysisBundle view (e.g. .model_level) -- checking that
+        # would never actually catch the multi-model case. Must check
+        # cr._analysis itself, same as _run_judge_alignment_if_needed does.
+        warnings.warn(
+            "Pareto-front analysis (secondary=) is not yet supported for "
+            "multi-model or factorial analyses. secondary= will be ignored "
+            "for this comparison.",
+            UserWarning,
+            stacklevel=4,
+        )
+        return
+    bundle = cr._primary_bundle()
+    if bundle.benchmark.is_seeded:
+        raise ValueError(
+            "Pareto-front analysis (secondary=) does not yet support seeded "
+            "benchmarks (R >= 3 repeated runs). Aggregate runs to a single "
+            "score per (template, input) cell before passing secondary=."
+        )
+
+    from evalstats.core.pareto import pareto_bootstrap, classify_pareto_status, orient_higher_is_better
+
+    labels = list(bundle.benchmark.template_labels)
+    input_labels = list(bundle.benchmark.input_labels)
+    n_entities = len(labels)
+    n_items = len(input_labels)
+    entity_idx = {e: i for i, e in enumerate(labels)}
+    item_idx = {it: j for j, it in enumerate(input_labels)}
+
+    # Primary metric's item-aligned score matrix (already computed by the
+    # main analysis) -- averaged over runs/evaluators the same way PPI's
+    # scores_2d is, so both metrics share the exact same (entity, item) grid.
+    scores_primary = bundle.benchmark.get_2d_scores()
+
+    # Secondary metric's item-aligned score matrix, built directly from the
+    # filtered dataframe the same way _run_alignment_ppi builds lab_matrix --
+    # more robust than re-deriving via from_dataframe() a second time, since
+    # it guarantees identical (entity, item) index alignment with scores_primary.
+    scores_secondary = np.full((n_entities, n_items), np.nan)
+    sec_rows = df[[factor_col, item_col, secondary_col]].dropna(subset=[secondary_col])
+    for e_val, it_val, s_val in zip(
+        sec_rows[factor_col].astype(str).to_numpy(),
+        sec_rows[item_col].astype(str).to_numpy(),
+        sec_rows[secondary_col].to_numpy(dtype=float),
+    ):
+        ei = entity_idx.get(e_val)
+        ij = item_idx.get(it_val)
+        if ei is not None and ij is not None:
+            scores_secondary[ei, ij] = s_val
+
+    if np.any(np.isnan(scores_secondary)):
+        n_missing = int(np.sum(np.isnan(scores_secondary)))
+        raise ValueError(
+            f"secondary='{secondary_col}' has {n_missing} missing (entity, item) "
+            f"cell(s) out of {n_entities * n_items} -- Pareto-front analysis "
+            "currently requires a complete design (every entity scored on "
+            "every item for the secondary metric too)."
+        )
+
+    scores_secondary_oriented = orient_higher_is_better(scores_secondary, direction)
+
+    result = pareto_bootstrap(
+        scores_primary, scores_secondary_oriented, labels,
+        n_bootstrap=n_boot, rng=np.random.default_rng(rng),
+    )
+    statuses = classify_pareto_status(result, alpha=alpha)
+
+    cr._pareto = {
+        "secondary_metric": secondary_col,
+        "direction": direction,
+        "result": result,
+        "statuses": statuses,
+    }
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # compare()
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1599,7 +1828,7 @@ def compare(
     baseline: Optional[str] = None,
     block: Union[str, list[str], Literal["auto"]] = "auto",
     slices=None,         # deferred
-    secondary=None,      # deferred
+    secondary: Optional[dict[str, Literal["min", "max"]]] = None,
     alignment=None,
     n_mc: int = 200,
     min_meaningful_diff=None,  # deferred
@@ -1633,6 +1862,22 @@ def compare(
     block : str, list[str], or "auto"
         Blocking variable(s) — typically ``"item"`` or ``"input"``.
         ``"auto"`` (default) uses the item column detected by ``load_from``.
+    secondary : dict[str, {"min", "max"}], optional
+        Run an uncertainty-aware Pareto-front analysis against a second
+        metric, e.g. ``secondary={"latency_ms": "min"}`` to find the
+        accuracy/latency frontier (``"min"`` for a cost-like metric where
+        lower is better, ``"max"`` for a benefit-like one). Currently
+        supports exactly one secondary metric, a complete design (every
+        entity scored on every item for it too), and a single-factor result
+        (not yet supported for multi-model/factorial comparisons or seeded
+        R>=3 benchmarks). Both metrics are resampled *jointly* (a shared
+        per-item bootstrap draw, not two independent marginal bootstraps)
+        so that correlation between them (e.g. harder items being both
+        slower and less accurate) is preserved rather than dropped, and a
+        marginally-better point estimate on both axes isn't reported as a
+        confident "dominates" call when the data can't actually support it.
+        See :attr:`ComparisonResult.pareto_status` /
+        :attr:`ComparisonResult.pareto_frontier_probability`.
     alpha : float, optional
         Significance level / CI width: ``alpha=0.05`` → 95 % CIs.
         When ``None`` (default), uses the global value set by
@@ -1701,8 +1946,6 @@ def compare(
     """
     if slices is not None:
         warnings.warn("slices= is not yet implemented and will be ignored.", UserWarning, stacklevel=2)
-    if secondary is not None:
-        warnings.warn("secondary= is not yet implemented and will be ignored.", UserWarning, stacklevel=2)
     # ── resolve alpha (explicit > global default) ─────────────────────────────
     if alpha is None:
         alpha = get_alpha_ci()
@@ -1877,6 +2120,11 @@ def compare(
             alpha=alpha, ci_level=ci_level, engine_kwargs=engine_kwargs,
             df=df, factor_col=factor_col_name, item_col=item_col, run_col=run_col,
         )
+        _run_pareto_if_needed(
+            cr, secondary=secondary, df=df, factor_col=factor_col_name,
+            item_col=item_col, alpha=alpha, n_boot=max(n_mc, 1000),
+            rng=engine_kwargs.get("rng"),
+        )
         return cr
 
     # ── path B: prompt/template comparison ───────────────────────────────────
@@ -1926,6 +2174,11 @@ def compare(
             alpha=alpha, ci_level=ci_level, engine_kwargs=engine_kwargs,
             df=df, factor_col=factor_col_name, item_col=item_col, run_col=run_col,
         )
+        _run_pareto_if_needed(
+            cr, secondary=secondary, df=df, factor_col=factor_col_name,
+            item_col=item_col, alpha=alpha, n_boot=max(n_mc, 1000),
+            rng=engine_kwargs.get("rng"),
+        )
         return cr
 
     # ── path C: arbitrary single factor column ────────────────────────────────
@@ -1957,6 +2210,11 @@ def compare(
             cr, alignment=alignment, metric_col=metric_col, n_mc=n_mc,
             alpha=alpha, ci_level=ci_level, engine_kwargs=engine_kwargs,
             df=df, factor_col=factor_col_name, item_col=item_col, run_col=run_col,
+        )
+        _run_pareto_if_needed(
+            cr, secondary=secondary, df=df, factor_col=factor_col_name,
+            item_col=item_col, alpha=alpha, n_boot=max(n_mc, 1000),
+            rng=engine_kwargs.get("rng"),
         )
         return cr
 

--- a/evalstats/api.py
+++ b/evalstats/api.py
@@ -1769,18 +1769,46 @@ def _run_pareto_if_needed(
         )
 
     scores_secondary_oriented = orient_higher_is_better(scores_secondary, direction)
+    rng_gen = np.random.default_rng(rng)
 
     result = pareto_bootstrap(
         scores_primary, scores_secondary_oriented, labels,
-        n_bootstrap=n_boot, rng=np.random.default_rng(rng),
+        n_bootstrap=n_boot, rng=rng_gen,
     )
     statuses = classify_pareto_status(result, alpha=alpha)
+
+    # Secondary metric's own calibrated marginal CI, in its real (un-oriented)
+    # units -- same auto data-kind/N routing analyze() uses for the primary
+    # metric (see router.py's _analyze_single), not a cheap percentile CI off
+    # the joint dominance bootstrap: that bootstrap is built for the
+    # dominance question, and reusing it here would quietly ship an
+    # uncalibrated shortcut for the one number this library is otherwise
+    # careful never to show uncalibrated.
+    from evalstats.core.resampling import is_binary_scores, resolve_score_bounds
+    from evalstats.core.variance import robustness_metrics
+    from evalstats.config import resolve_auto_analyze_methods
+
+    if is_binary_scores(scores_secondary):
+        sec_data_kind = "binary"
+        sec_score_range = None
+    else:
+        sec_score_range = resolve_score_bounds(scores_secondary, None, stacklevel=5)
+        sec_data_kind = "bounded_01" if sec_score_range is not None else "unbounded"
+    _, sec_robustness_method = resolve_auto_analyze_methods(sec_data_kind, n_items, seeded=False)
+    secondary_robustness = robustness_metrics(
+        scores_secondary, labels,
+        n_bootstrap=n_boot, rng=rng_gen, alpha=alpha,
+        marginal_method=sec_robustness_method,
+        score_range=sec_score_range,
+    )
 
     cr._pareto = {
         "secondary_metric": secondary_col,
         "direction": direction,
         "result": result,
         "statuses": statuses,
+        "primary_robustness": bundle.robustness,
+        "secondary_robustness": secondary_robustness,
     }
 
 

--- a/evalstats/api.py
+++ b/evalstats/api.py
@@ -134,41 +134,9 @@ class ComparisonResult:
             min_meaningful_diff=self._min_meaningful_diff,
             item_singular=item_singular,
             item_plural=item_plural,
+            pareto=self._pareto,
+            metric=self._metric,
         )
-        if self._pareto is not None:
-            self._print_pareto_summary(show_rank_probabilities=show_rank)
-
-    def _print_pareto_summary(self, *, show_rank_probabilities: bool) -> None:
-        secondary_col = self._pareto["secondary_metric"]
-        direction = self._pareto["direction"]
-        statuses = self._pareto["statuses"]
-        result = self._pareto["result"]
-
-        dir_label = "lower is better" if direction == "min" else "higher is better"
-        print()
-        print(f"--- Pareto Front ({self._metric} vs {secondary_col}, {dir_label}) ---")
-        label_w = max((len(lbl) for lbl in result.labels), default=6)
-        label_w = max(label_w, len("Entity"))
-        status_w = max(len("Ambiguous"), len("Dominated"), len("Frontier"))
-        header = f"  {'Entity':<{label_w}}  {'Status':<{status_w}}  Detail"
-        print(header)
-        print("  " + "-" * (len(header) - 2))
-        for label in result.labels:
-            st = statuses[label]
-            status_disp = st.status.capitalize()
-            if st.status == "dominated":
-                detail = f"by {', '.join(st.dominated_by)}"
-            elif st.status == "ambiguous":
-                detail = f"vs {', '.join(st.ambiguous_vs)} (not statistically confirmed)"
-            else:
-                detail = ""
-            print(f"  {label:<{label_w}}  {status_disp:<{status_w}}  {detail}")
-        print("  " + "-" * (len(header) - 2))
-        if show_rank_probabilities:
-            print("\n  P(Pareto-optimal):")
-            for label, p in zip(result.labels, result.p_frontier):
-                print(f"    {label:<{label_w}}  {p:>6.1%}")
-        print()
 
     def brief(self) -> None:
         """Print a compact one-line-per-entity summary."""

--- a/evalstats/core/pareto.py
+++ b/evalstats/core/pareto.py
@@ -1,0 +1,285 @@
+"""Uncertainty-aware Pareto-front analysis for a primary metric + secondary metric(s).
+
+Backs ``compare(..., secondary=...)``. Unlike a naive Pareto front on point
+estimates -- which lets a marginally-lower cost or marginally-higher accuracy
+count as "dominates" even when the underlying data can't distinguish the two
+entities -- this module resamples both metrics jointly (same shared per-item
+bootstrap index per replicate, the same idiom :func:`~evalstats.core.paired.all_pairwise`
+uses for its own joint pairwise resampling) so that dominance calls only fire
+when the data actually supports them, and so that correlation between the two
+metrics (e.g. harder items being both slower and less accurate) is preserved
+rather than silently dropped by two independent marginal bootstraps.
+
+The joint replicates are the single source of truth for two different
+summaries of the same underlying uncertainty:
+
+* :func:`pareto_bootstrap` -- computes, per bootstrap replicate, which
+  entities are on the empirical (point-in-that-replicate) Pareto frontier,
+  and which entity dominates which. Tallying across replicates gives both a
+  continuous ``P(entity is Pareto-optimal)`` and a bootstrap dominance
+  probability for every ordered pair.
+* :func:`classify_pareto_status` -- reduces those same tallies to a default,
+  calibrated three-state label per entity ("frontier" / "dominated" /
+  "ambiguous"), FWER-aware across the N-1 possible dominators of each entity,
+  mirroring how :attr:`~evalstats.api.ComparisonResult.unbeaten` reports a
+  set rather than a single "winner" for the single-metric case.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+import numpy as np
+
+
+@dataclass
+class ParetoBootstrapResult:
+    """Joint bootstrap dominance tallies for a primary + secondary metric.
+
+    Both metrics are assumed already oriented so that **higher is better**
+    (the caller negates a "minimize" metric, e.g. latency, before calling --
+    see :func:`orient_higher_is_better`). All comparisons here are therefore
+    a single, direction-agnostic ">= on both axes, > on at least one"
+    dominance rule.
+
+    Attributes
+    ----------
+    labels : list[str]
+        Entity labels, in the order all other arrays are indexed.
+    point_primary : np.ndarray
+        Shape ``(N,)``. Point estimate (mean or median) of the primary
+        metric per entity, on the original per-item data (not resampled).
+    point_secondary : np.ndarray
+        Shape ``(N,)``. Point estimate of the secondary metric per entity.
+    p_frontier : np.ndarray
+        Shape ``(N,)``. Fraction of bootstrap replicates in which entity i
+        was on the empirical (that replicate's own point values) Pareto
+        frontier -- i.e. not dominated by any other entity in that replicate.
+        This *is* ``P(entity is Pareto-optimal)`` -- the opt-in continuous
+        output; no covariance-matrix fitting involved, since it's a direct
+        tally over the empirical joint bootstrap distribution.
+    p_dominated_by : np.ndarray
+        Shape ``(N, N)``. ``p_dominated_by[i, j]`` = fraction of replicates
+        in which entity j dominates entity i (both metrics at least as
+        good, strictly better on at least one). Diagonal is always 0.
+    n_bootstrap : int
+        Number of bootstrap replicates the tallies above were computed from.
+    """
+
+    labels: list[str]
+    point_primary: np.ndarray
+    point_secondary: np.ndarray
+    p_frontier: np.ndarray
+    p_dominated_by: np.ndarray
+    n_bootstrap: int
+
+
+def orient_higher_is_better(scores: np.ndarray, direction: Literal["max", "min"]) -> np.ndarray:
+    """Return *scores* (or its negation) so that higher is always better.
+
+    :func:`pareto_bootstrap` and :func:`classify_pareto_status` only ever
+    reason about ">= on both axes, > on at least one" -- callers with a
+    "minimize" metric (e.g. latency, cost) negate it through this function
+    first rather than the engine carrying direction-handling logic itself.
+    """
+    if direction == "max":
+        return scores
+    if direction == "min":
+        return -scores
+    raise ValueError(f"direction must be 'max' or 'min', got {direction!r}")
+
+
+def pareto_bootstrap(
+    scores_primary: np.ndarray,
+    scores_secondary: np.ndarray,
+    labels: list[str],
+    n_bootstrap: int,
+    rng: np.random.Generator,
+    *,
+    statistic: Literal["mean", "median"] = "mean",
+    batch_size: int = 256,
+) -> ParetoBootstrapResult:
+    """Joint bootstrap Pareto-dominance tallies for two per-item-aligned metrics.
+
+    Draws one shared per-item resample index per replicate (applied to every
+    entity and both metrics at once -- the same "shared draw" idiom
+    :func:`~evalstats.core.paired._joint_bootstrap_critical_value` uses),
+    computes each entity's per-replicate (primary, secondary) point value,
+    and tallies (a) which entities are non-dominated in that replicate and
+    (b) which entity dominates which. Both metrics must already be oriented
+    so higher is better (see :func:`orient_higher_is_better`) and measured on
+    the same items (paired by column position), so that the shared resample
+    preserves whatever correlation exists between them.
+
+    Parameters
+    ----------
+    scores_primary, scores_secondary : np.ndarray
+        Shape ``(N, M)`` -- one row per entity, one column per item, same
+        item alignment for both arrays (column j is the same item in both).
+    labels : list[str]
+        Entity labels, length N.
+    n_bootstrap : int
+        Number of bootstrap replicates.
+    rng : np.random.Generator
+    statistic : {"mean", "median"}
+        Per-entity, per-replicate central-tendency statistic.
+    batch_size : int
+        Replicates processed per chunk, bounding peak memory for the
+        ``(N, N, batch)`` pairwise-dominance array (mirrors the chunking
+        pattern used elsewhere in this codebase, e.g.
+        :func:`~evalstats.core.paired.romano_wolf_stepdown_pvalues`).
+
+    Returns
+    -------
+    ParetoBootstrapResult
+    """
+    N, M = scores_primary.shape
+    if scores_secondary.shape != scores_primary.shape:
+        raise ValueError(
+            f"scores_primary and scores_secondary must have the same shape "
+            f"(same entities, same items); got {scores_primary.shape} vs "
+            f"{scores_secondary.shape}."
+        )
+    if len(labels) != N:
+        raise ValueError(f"labels must have length {N}, got {len(labels)}.")
+
+    def _stat(a: np.ndarray, axis: int) -> np.ndarray:
+        return a.mean(axis=axis) if statistic == "mean" else np.median(a, axis=axis)
+
+    point_primary = _stat(scores_primary, axis=1)
+    point_secondary = _stat(scores_secondary, axis=1)
+
+    frontier_count = np.zeros(N)
+    dominated_count = np.zeros((N, N))  # [i, j] += 1 when j dominates i, this replicate
+    eye = np.eye(N, dtype=bool)
+
+    start = 0
+    while start < n_bootstrap:
+        stop = min(start + batch_size, n_bootstrap)
+        b = stop - start
+        idx = rng.integers(0, M, size=(b, M))  # shared across every entity and both metrics
+
+        r1 = scores_primary[:, idx]    # (N, b, M)
+        r2 = scores_secondary[:, idx]  # (N, b, M)
+        bm1 = _stat(r1, axis=2)  # (N, b)
+        bm2 = _stat(r2, axis=2)  # (N, b)
+
+        m1_i, m1_j = bm1[:, None, :], bm1[None, :, :]  # (N,1,b), (1,N,b)
+        m2_i, m2_j = bm2[:, None, :], bm2[None, :, :]
+        ge_both = (m1_j >= m1_i) & (m2_j >= m2_i)
+        gt_either = (m1_j > m1_i) | (m2_j > m2_i)
+        j_dominates_i = ge_both & gt_either  # (N, N, b)
+        j_dominates_i &= ~eye[:, :, None]    # an entity cannot dominate itself
+
+        dominated_count += j_dominates_i.sum(axis=2)
+        i_is_dominated = j_dominates_i.any(axis=1)  # (N, b)
+        frontier_count += (~i_is_dominated).sum(axis=1)
+
+        start = stop
+
+    return ParetoBootstrapResult(
+        labels=list(labels),
+        point_primary=point_primary,
+        point_secondary=point_secondary,
+        p_frontier=frontier_count / n_bootstrap,
+        p_dominated_by=dominated_count / n_bootstrap,
+        n_bootstrap=n_bootstrap,
+    )
+
+
+@dataclass
+class ParetoStatus:
+    """Default three-state Pareto classification for one entity.
+
+    Attributes
+    ----------
+    label : str
+        Entity label.
+    status : {"frontier", "dominated", "ambiguous"}
+        - ``"frontier"``: not confidently dominated by anyone at *alpha*
+          (Bonferroni-adjusted across the N-1 possible dominators), *and*
+          the entity's own point estimate is itself on the raw
+          point-estimate Pareto frontier -- the calibrated, "safe" verdict.
+        - ``"dominated"``: confidently dominated by at least one specific
+          entity at *alpha* -- ``dominated_by`` lists them.
+        - ``"ambiguous"``: not confidently dominated by anyone, but the
+          entity's own point estimate is beaten on both axes by some other
+          entity's point estimate too -- there just isn't enough evidence to
+          confirm that dominance statistically. This is the "can't rule it
+          out either way" case a naive point-estimate-only Pareto front
+          would silently misreport as a clean frontier member.
+          ``ambiguous_vs`` lists the entities responsible.
+    dominated_by : list[str]
+        Entities that confidently dominate this one (empty unless
+        ``status == "dominated"``).
+    ambiguous_vs : list[str]
+        Entities whose point estimate dominates this one's, without enough
+        evidence to confirm it (empty unless ``status == "ambiguous"``).
+    """
+
+    label: str
+    status: Literal["frontier", "dominated", "ambiguous"]
+    dominated_by: list[str] = field(default_factory=list)
+    ambiguous_vs: list[str] = field(default_factory=list)
+
+
+def classify_pareto_status(
+    result: ParetoBootstrapResult,
+    *,
+    alpha: float = 0.05,
+) -> dict[str, ParetoStatus]:
+    """Reduce :class:`ParetoBootstrapResult` to a default three-state label per entity.
+
+    Dominance calls are Bonferroni-adjusted across the N-1 possible
+    dominators of each entity (mirrors the FWER-control philosophy already
+    used for pairwise significance elsewhere in evalstats): entity i is
+    "dominated" only when some j clears ``p_dominated_by[i, j] >= 1 - alpha
+    / (N - 1)``, not just the raw ``1 - alpha`` -- checking N-1 possible
+    dominators per entity is itself a multiple-comparisons problem.
+
+    Parameters
+    ----------
+    result : ParetoBootstrapResult
+        Output of :func:`pareto_bootstrap`.
+    alpha : float
+        Significance level (e.g. 0.05 -> 95% confidence a claimed
+        domination is real).
+
+    Returns
+    -------
+    dict[str, ParetoStatus]
+        Keyed by entity label.
+    """
+    labels = result.labels
+    N = len(labels)
+    threshold = 1.0 - (alpha / max(N - 1, 1))
+
+    # Raw point-estimate Pareto frontier (no uncertainty) -- used only to
+    # distinguish "frontier" from "ambiguous" once an entity isn't
+    # confidently dominated by anyone.
+    p1, p2 = result.point_primary, result.point_secondary
+    point_dominated_by: dict[int, list[int]] = {i: [] for i in range(N)}
+    for i in range(N):
+        for j in range(N):
+            if i == j:
+                continue
+            dominates = (p1[j] >= p1[i]) and (p2[j] >= p2[i]) and (p1[j] > p1[i] or p2[j] > p2[i])
+            if dominates:
+                point_dominated_by[i].append(j)
+
+    statuses: dict[str, ParetoStatus] = {}
+    for i, label in enumerate(labels):
+        confident_dominators = [
+            labels[j] for j in range(N) if j != i and result.p_dominated_by[i, j] >= threshold
+        ]
+        if confident_dominators:
+            statuses[label] = ParetoStatus(label=label, status="dominated", dominated_by=confident_dominators)
+        elif point_dominated_by[i]:
+            statuses[label] = ParetoStatus(
+                label=label, status="ambiguous",
+                ambiguous_vs=[labels[j] for j in point_dominated_by[i]],
+            )
+        else:
+            statuses[label] = ParetoStatus(label=label, status="frontier")
+    return statuses

--- a/evalstats/core/summary.py
+++ b/evalstats/core/summary.py
@@ -215,6 +215,8 @@ def print_analysis_summary(
     item_singular: str = "template",
     item_plural: str = "templates",
     show_rank_probabilities: bool = False,
+    pareto: Optional[dict] = None,
+    metric: Optional[str] = None,
 ) -> None:
     """Print a concise console summary of analyze() results.
 
@@ -256,6 +258,8 @@ def print_analysis_summary(
             item_singular=item_singular,
             item_plural=item_plural,
             show_rank_probabilities=show_rank_probabilities,
+            pareto=pareto,
+            metric=metric,
         )
         return
 
@@ -1417,6 +1421,8 @@ def _print_bundle_summary(
     guidance: bool = True,
     min_meaningful_diff: Optional[float] = None,
     show_rank_probabilities: bool = False,
+    pareto: Optional[dict] = None,
+    metric: Optional[str] = None,
 ) -> None:
     if p_value_method is _UNSET:
         p_value_method = bundle.p_value_method
@@ -1502,7 +1508,15 @@ def _print_bundle_summary(
         print()
         _print_factorial_lmm_summary(bundle, item_singular=item_singular, style=style)
 
-    # Executive summary leaderboard (always last — immediately visible in terminal).
+    # Pareto front (primary metric vs. a secondary metric), when present --
+    # printed right before the executive summary so the secondary-metric-
+    # corrected, holistic verdict sits next to the primary-metric-only
+    # leaderboard rather than trailing after everything else.
+    if pareto is not None:
+        print()
+        _print_pareto_section(pareto, metric=metric, show_rank_probabilities=show_rank_probabilities)
+
+    # Executive summary leaderboard (near the end — immediately visible in terminal).
     print()
     _print_executive_summary(bundle, item_singular=item_singular)
 
@@ -2586,6 +2600,52 @@ def _exec_verdict(
     if len(others) == 1:
         return f"Tied with {_truncate_label(others[0], 20)} as best"
     return f"Tied with {len(others)} others as best"
+
+
+def _print_pareto_section(
+    pareto: dict,
+    *,
+    metric: Optional[str],
+    show_rank_probabilities: bool,
+) -> None:
+    """Print the Pareto Front section (frontier/dominated/ambiguous per
+    entity against a secondary metric) -- see ``ComparisonResult.pareto_status``.
+
+    Printed immediately before the executive summary (see
+    ``_print_bundle_summary``) so the secondary-metric-corrected, holistic
+    verdict sits right next to the primary-metric-only leaderboard, rather
+    than trailing after everything else where it's easy to miss.
+    """
+    secondary_col = pareto["secondary_metric"]
+    direction = pareto["direction"]
+    statuses = pareto["statuses"]
+    result = pareto["result"]
+
+    dir_label = "lower is better" if direction == "min" else "higher is better"
+    metric_label = metric or "primary metric"
+    _print_subsection(f"--- Pareto Front ({metric_label} vs {secondary_col}, {dir_label}) ---")
+    label_w = max((len(lbl) for lbl in result.labels), default=6)
+    label_w = max(label_w, len("Entity"))
+    status_w = max(len("Ambiguous"), len("Dominated"), len("Frontier"))
+    header = f"  {'Entity':<{label_w}}  {'Status':<{status_w}}  Detail"
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for label in result.labels:
+        st = statuses[label]
+        status_disp = st.status.capitalize()
+        if st.status == "dominated":
+            detail = f"by {', '.join(st.dominated_by)}"
+        elif st.status == "ambiguous":
+            detail = f"vs {', '.join(st.ambiguous_vs)} (not statistically confirmed)"
+        else:
+            detail = ""
+        print(f"  {label:<{label_w}}  {status_disp:<{status_w}}  {detail}")
+    print("  " + "-" * (len(header) - 2))
+    if show_rank_probabilities:
+        print("\n  P(Pareto-optimal):")
+        for label, p in zip(result.labels, result.p_frontier):
+            print(f"    {label:<{label_w}}  {p:>6.1%}")
+    print()
 
 
 def _print_executive_summary(

--- a/evalstats/core/summary.py
+++ b/evalstats/core/summary.py
@@ -2625,19 +2625,149 @@ def _pareto_sorted_labels(pareto: dict) -> list[str]:
     )
 
 
+# Glyph + color per Pareto status, shared by the table's merged Status
+# column, the Executive Summary's Pareto column, and the scatterplot below --
+# one visual vocabulary across every place a status shows up.
+_PARETO_STATUS_GLYPH = {"frontier": "★", "ambiguous": "◌", "dominated": "×"}
+
+
+def _pareto_status_glyph(status: str) -> str:
+    return _PARETO_STATUS_GLYPH.get(status, "?")
+
+
+def _pareto_status_color(status: str) -> str:
+    if not _ANSI:
+        return ""
+    if status == "frontier":
+        return _BRIGHT_GREEN
+    if status == "dominated":
+        return _DIM
+    return _YELLOW  # ambiguous
+
+
 def _pareto_status_phrase(status: "ParetoStatus", *, verbose: bool = True) -> str:
-    """One-cell phrase combining a ParetoStatus's status word with its
-    detail (dominated_by / ambiguous_vs), e.g. "Dominated by gpt-4o" --
-    used by both the Pareto Front table (verbose=True, includes the
-    "(not confirmed)" qualifier) and the Executive Summary's narrower
-    Pareto column (verbose=False, drops it)."""
-    label = status.status.capitalize()
+    """One-cell phrase combining a ParetoStatus's glyph with plain-language
+    wording and its detail (dominated_by / ambiguous_vs), e.g.
+    "× Worse than gpt-4o on both" -- used by both the Pareto Front table
+    (verbose=True, includes the "(not confirmed)" qualifier) and the
+    Executive Summary's narrower Pareto column (verbose=False, drops it)."""
+    glyph = _pareto_status_glyph(status.status)
     if status.status == "dominated":
-        return f"{label} by {', '.join(status.dominated_by)}"
-    if status.status == "ambiguous":
+        text = f"Worse than {', '.join(status.dominated_by)} on both"
+    elif status.status == "ambiguous":
         suffix = " (not confirmed)" if verbose else ""
-        return f"{label} vs {', '.join(status.ambiguous_vs)}{suffix}"
-    return label
+        text = f"Unclear vs {', '.join(status.ambiguous_vs)}{suffix}"
+    else:
+        text = "Best trade-off"
+    return f"{glyph} {text}"
+
+
+def _print_pareto_scatter(
+    pareto: dict,
+    *,
+    metric_label: str,
+    width: int = 44,
+    height: int = 9,
+) -> None:
+    """Print a compact ASCII scatterplot of primary vs. secondary metric,
+    one point per entity, marked with its Pareto status glyph (see
+    ``_pareto_status_glyph``) so the trade-off shape between metrics is
+    visible at a glance, before the reader has to parse the numeric table
+    below. Points are numbered (1, 2, 3, ...) rather than labeled by name
+    to sidestep collisions when entities sit close together on the plot;
+    a legend below maps each number back to its entity name.
+    """
+    result = pareto["result"]
+    statuses = pareto["statuses"]
+    secondary_col = pareto["secondary_metric"]
+    direction = pareto["direction"]
+    primary_rob = pareto.get("primary_robustness")
+    secondary_rob = pareto.get("secondary_robustness")
+    if primary_rob is None or secondary_rob is None or len(result.labels) < 2:
+        return
+
+    sorted_labels = _pareto_sorted_labels(pareto)
+    prim_idx = {lbl: i for i, lbl in enumerate(primary_rob.labels)}
+    sec_idx = {lbl: i for i, lbl in enumerate(secondary_rob.labels)}
+    xs = [float(secondary_rob.mean[sec_idx[lbl]]) for lbl in sorted_labels]
+    ys = [float(primary_rob.mean[prim_idx[lbl]]) for lbl in sorted_labels]
+
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+    x_pad = max((x_max - x_min) * 0.08, abs(x_max) * 1e-6, 1e-9)
+    y_pad = max((y_max - y_min) * 0.08, abs(y_max) * 1e-6, 1e-9)
+    x_lo, x_hi = x_min - x_pad, x_max + x_pad
+    y_lo, y_hi = y_min - y_pad, y_max + y_pad
+
+    markers = "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+    def _marker(i: int) -> str:
+        return markers[i] if i < len(markers) else "#"
+
+    grid = [[" "] * width for _ in range(height)]
+    occupied: dict[tuple[int, int], list[int]] = {}
+    for i, (x, y) in enumerate(zip(xs, ys)):
+        col = int(round((x - x_lo) / (x_hi - x_lo) * (width - 1)))
+        row = int(round((y_hi - y) / (y_hi - y_lo) * (height - 1)))
+        col = min(max(col, 0), width - 1)
+        row = min(max(row, 0), height - 1)
+        occupied.setdefault((row, col), []).append(i)
+
+    for (row, col), idxs in occupied.items():
+        # The first entity claiming a cell gets the glyph; cells shared by
+        # more than one entity are flagged in a note below rather than
+        # silently overwritten.
+        lead = idxs[0]
+        status = statuses[sorted_labels[lead]].status
+        color = _pareto_status_color(status)
+        reset = _RESET if color else ""
+        grid[row][col] = f"{color}{_marker(lead)}{reset}"
+
+    y_label_w = 9
+    print(f"  {metric_label:>{y_label_w}}")
+    for row in range(height):
+        if row == 0:
+            y_tick = f"{y_hi:>{y_label_w}.3g}"
+        elif row == height - 1:
+            y_tick = f"{y_lo:>{y_label_w}.3g}"
+        else:
+            y_tick = " " * y_label_w
+        print(f"  {y_tick} │{''.join(grid[row])}│")
+    border = "─" * width
+    print(f"  {'':>{y_label_w}} └{border}┘")
+    dir_arrow = "→ better" if direction == "max" else "← better"
+    x_axis_label = f"{secondary_col} ({dir_arrow})"
+    x_min_str = f"{x_min:.3g}"
+    x_max_str = f"{x_max:.3g}"
+    print(
+        f"  {'':>{y_label_w}}  {x_min_str}"
+        f"{x_axis_label:^{max(width - 12, 4)}}"
+        f"{x_max_str}"
+    )
+    print()
+
+    legend_cells = []
+    for i, lbl in enumerate(sorted_labels):
+        status = statuses[lbl].status
+        color = _pareto_status_color(status)
+        reset = _RESET if color else ""
+        legend_cells.append(f"{color}{_marker(i)}{reset}={_truncate_label(lbl, 20)}")
+    # Wrap the legend at a reasonable width instead of one long line.
+    line = "  "
+    for cell in legend_cells:
+        plain_len = len(re.sub(r"\033\[[0-9;]*m", "", cell))
+        if len(re.sub(r"\033\[[0-9;]*m", "", line)) + plain_len + 3 > 78 and line.strip():
+            print(line.rstrip())
+            line = "  "
+        line += cell + "   "
+    if line.strip():
+        print(line.rstrip())
+
+    collisions = [idxs for idxs in occupied.values() if len(idxs) > 1]
+    for idxs in collisions:
+        names = ", ".join(_marker(i) for i in idxs)
+        print(f"  ({names} sit at nearly the same spot on this plot)")
+    print()
 
 
 def _print_pareto_section(
@@ -2674,6 +2804,12 @@ def _print_pareto_section(
         f"--- {metric_label} vs. {secondary_col} Tradeoff "
         f"(Pareto Front, {dir_label}) ---"
     )
+    print(
+        f"  A model has the 'best trade-off' when no other option beats it "
+        f"on both {metric_label} and {secondary_col} at once."
+    )
+    print()
+    _print_pareto_scatter(pareto, metric_label=metric_label)
 
     sorted_labels = _pareto_sorted_labels(pareto)
     label_w = max((len(lbl) for lbl in result.labels), default=6)
@@ -2708,7 +2844,9 @@ def _print_pareto_section(
     print("  " + "-" * (len(header) - 2))
 
     for label in sorted_labels:
-        status_disp = phrases[label]
+        status_disp = f"{phrases[label]:<{status_w}}"
+        color = _pareto_status_color(statuses[label].status)
+        status_str = f"{color}{status_disp}{_RESET}" if color else status_disp
         if have_stats:
             pi, si = prim_idx[label], sec_idx[label]
             p_mean = float(primary_rob.mean[pi])
@@ -2722,18 +2860,23 @@ def _print_pareto_section(
                 if secondary_rob.ci_low is not None else "--"
             )
             print(
-                f"  {label:<{label_w}}  {status_disp:<{status_w}}  "
+                f"  {label:<{label_w}}  {status_str}  "
                 f"{p_mean:>{mean_w}.3g} {p_ci:<{ci_w}s}  "
                 f"{s_mean:>{mean_w}.3g} {s_ci:<{ci_w}s}"
             )
         else:
-            print(f"  {label:<{label_w}}  {status_disp:<{status_w}}")
+            print(f"  {label:<{label_w}}  {status_str}")
     print("  " + "-" * (len(header) - 2))
     if show_rank_probabilities:
-        print("\n  P(Pareto-optimal):")
+        print()
+        print("  How confident are we in each trade-off call?")
+        print("  (P(Pareto-optimal): share of bootstrap resamples this entity wasn't beaten on both axes in)")
+        bar_w = 20
         for label in sorted_labels:
             p = float(result.p_frontier[result.labels.index(label)])
-            print(f"    {label:<{label_w}}  {p:>6.1%}")
+            color = _p_best_color(p)
+            reset = _RESET if color else ""
+            print(f"    {label:<{label_w}}  {p:>6.1%} {color}{_ratio_bar(p, width=bar_w)}{reset}")
     print()
 
 
@@ -2752,7 +2895,7 @@ def _print_executive_summary(
     assess results at a glance without scrolling up. The Pareto column
     surfaces the secondary-metric verdict right next to the primary-metric
     one, e.g. an entity that's "Likely best" on the primary metric but
-    "Dominated" once the secondary metric is considered.
+    "Worse than X on both" once the secondary metric is considered.
     """
     labels = list(bundle.rank_dist.labels)
     n = len(labels)
@@ -2848,8 +2991,13 @@ def _print_executive_summary(
             row += f"  {stab_str:<{stab_w}s}"
 
         if has_pareto:
-            pareto_str = pareto_phrases.get(label, "—")
-            row += f"  {pareto_str:<{pareto_w}s}"
+            pareto_plain = f"{pareto_phrases.get(label, '—'):<{pareto_w}s}"
+            pareto_color = (
+                _pareto_status_color(pareto_statuses[label].status)
+                if label in pareto_statuses else ""
+            )
+            pareto_str = f"{pareto_color}{pareto_plain}{_RESET}" if pareto_color else pareto_plain
+            row += f"  {pareto_str}"
 
         row += f"  {verdict_str}"
         print(row)

--- a/evalstats/core/summary.py
+++ b/evalstats/core/summary.py
@@ -2965,7 +2965,16 @@ def _print_executive_summary(
     mean_w = 6
     ci_w = 15  # e.g. "[0.950, 0.990]" = 14 chars + 1 padding
     stab_w = 16
-    pareto_w = max([len("Trade-off")] + [len(p) for p in pareto_phrases.values()]) if has_pareto else 0
+    # "Trade-off vs {secondary}" names the second axis explicitly (truncated
+    # -- an arbitrary column name shouldn't be able to blow out this table's
+    # width), pairing with "On {metric}" below so the two columns' headers
+    # alone state both axes without needing the Pareto section above.
+    tradeoff_secondary = pareto.get("secondary_metric") if has_pareto else None
+    tradeoff_header = (
+        f"Trade-off vs {_truncate_label(tradeoff_secondary, 16)}"
+        if tradeoff_secondary else "Trade-off"
+    )
+    pareto_w = max([len(tradeoff_header)] + [len(p) for p in pareto_phrases.values()]) if has_pareto else 0
 
     # CI column header: Wilson CI when no bootstrap was used (binary data path).
     ci_col_header = "Wilson CI" if _uses_wilson_ci(bundle) else "CI"
@@ -2980,7 +2989,7 @@ def _print_executive_summary(
     if has_stability:
         header_parts.append(f"  {'Stability':<{stab_w}s}")
     if has_pareto:
-        header_parts.append(f"  {'Trade-off':<{pareto_w}s}")
+        header_parts.append(f"  {tradeoff_header:<{pareto_w}s}")
     verdict_header = f"On {metric or 'primary metric'}" if has_pareto else "Verdict"
     header_parts.append(f"  {verdict_header}")
     header = "".join(header_parts)

--- a/evalstats/core/summary.py
+++ b/evalstats/core/summary.py
@@ -1518,7 +1518,7 @@ def _print_bundle_summary(
 
     # Executive summary leaderboard (near the end — immediately visible in terminal).
     print()
-    _print_executive_summary(bundle, item_singular=item_singular)
+    _print_executive_summary(bundle, item_singular=item_singular, pareto=pareto)
 
     if guidance:
         _print_next_steps_guidance(
@@ -2602,6 +2602,27 @@ def _exec_verdict(
     return f"Tied with {len(others)} others as best"
 
 
+# Sort priority for Pareto status groups: frontier first (the calibrated
+# "safe" verdict), then ambiguous (can't rule dominance in or out), then
+# dominated last.
+_PARETO_STATUS_ORDER = {"frontier": 0, "ambiguous": 1, "dominated": 2}
+
+
+def _pareto_sorted_labels(pareto: dict) -> list[str]:
+    """Entity order for the Pareto Front table: status group, then primary
+    metric mean descending within each group."""
+    result = pareto["result"]
+    statuses = pareto["statuses"]
+    point_primary = dict(zip(result.labels, result.point_primary))
+    return sorted(
+        result.labels,
+        key=lambda lbl: (
+            _PARETO_STATUS_ORDER.get(statuses[lbl].status, 3),
+            -point_primary[lbl],
+        ),
+    )
+
+
 def _print_pareto_section(
     pareto: dict,
     *,
@@ -2615,35 +2636,90 @@ def _print_pareto_section(
     ``_print_bundle_summary``) so the secondary-metric-corrected, holistic
     verdict sits right next to the primary-metric-only leaderboard, rather
     than trailing after everything else where it's easy to miss.
+
+    Shows each metric's own calibrated mean + CI side by side (not just the
+    status label) -- ``pareto["primary_robustness"]``/``["secondary_robustness"]``
+    are the same kind of :class:`~evalstats.core.variance.RobustnessResult`
+    the rest of evalstats already shows for a single metric, so the numbers
+    here carry the same guarantees. Sorted frontier -> ambiguous -> dominated
+    (see :func:`_pareto_sorted_labels`), not raw entity order.
     """
     secondary_col = pareto["secondary_metric"]
     direction = pareto["direction"]
     statuses = pareto["statuses"]
     result = pareto["result"]
+    primary_rob = pareto.get("primary_robustness")
+    secondary_rob = pareto.get("secondary_robustness")
 
     dir_label = "lower is better" if direction == "min" else "higher is better"
     metric_label = metric or "primary metric"
     _print_subsection(f"--- Pareto Front ({metric_label} vs {secondary_col}, {dir_label}) ---")
+
+    sorted_labels = _pareto_sorted_labels(pareto)
     label_w = max((len(lbl) for lbl in result.labels), default=6)
     label_w = max(label_w, len("Entity"))
     status_w = max(len("Ambiguous"), len("Dominated"), len("Frontier"))
-    header = f"  {'Entity':<{label_w}}  {'Status':<{status_w}}  Detail"
+    mean_w = 7
+    ci_w = 17
+
+    have_stats = primary_rob is not None and secondary_rob is not None
+    if have_stats:
+        prim_idx = {lbl: i for i, lbl in enumerate(primary_rob.labels)}
+        sec_idx = {lbl: i for i, lbl in enumerate(secondary_rob.labels)}
+        # Left-aligned (not centered) so each metric name reads as a label
+        # spanning its own "Mean 95% CI" pair starting directly above the
+        # Mean column, rather than visually drifting toward the wider CI
+        # sub-column when centered over the combined width.
+        metric_row = (
+            f"  {'':<{label_w}}  {'':<{status_w}}  "
+            f"{_truncate_label(metric_label, mean_w + ci_w + 1):<{mean_w + ci_w + 1}s}  "
+            f"{_truncate_label(secondary_col, mean_w + ci_w + 1):<{mean_w + ci_w + 1}s}"
+        )
+        print(metric_row)
+        header = (
+            f"  {'Entity':<{label_w}}  {'Status':<{status_w}}  "
+            f"{'Mean':>{mean_w}s} {'95% CI':<{ci_w}s}  "
+            f"{'Mean':>{mean_w}s} {'95% CI':<{ci_w}s}  Detail"
+        )
+    else:
+        header = f"  {'Entity':<{label_w}}  {'Status':<{status_w}}  Detail"
     print(header)
     print("  " + "-" * (len(header) - 2))
-    for label in result.labels:
+
+    for label in sorted_labels:
         st = statuses[label]
         status_disp = st.status.capitalize()
         if st.status == "dominated":
             detail = f"by {', '.join(st.dominated_by)}"
         elif st.status == "ambiguous":
-            detail = f"vs {', '.join(st.ambiguous_vs)} (not statistically confirmed)"
+            detail = f"vs {', '.join(st.ambiguous_vs)} (not confirmed)"
         else:
             detail = ""
-        print(f"  {label:<{label_w}}  {status_disp:<{status_w}}  {detail}")
+
+        if have_stats:
+            pi, si = prim_idx[label], sec_idx[label]
+            p_mean = float(primary_rob.mean[pi])
+            p_ci = (
+                f"[{primary_rob.ci_low[pi]:.3g}, {primary_rob.ci_high[pi]:.3g}]"
+                if primary_rob.ci_low is not None else "--"
+            )
+            s_mean = float(secondary_rob.mean[si])
+            s_ci = (
+                f"[{secondary_rob.ci_low[si]:.3g}, {secondary_rob.ci_high[si]:.3g}]"
+                if secondary_rob.ci_low is not None else "--"
+            )
+            print(
+                f"  {label:<{label_w}}  {status_disp:<{status_w}}  "
+                f"{p_mean:>{mean_w}.3g} {p_ci:<{ci_w}s}  "
+                f"{s_mean:>{mean_w}.3g} {s_ci:<{ci_w}s}  {detail}"
+            )
+        else:
+            print(f"  {label:<{label_w}}  {status_disp:<{status_w}}  {detail}")
     print("  " + "-" * (len(header) - 2))
     if show_rank_probabilities:
         print("\n  P(Pareto-optimal):")
-        for label, p in zip(result.labels, result.p_frontier):
+        for label in sorted_labels:
+            p = float(result.p_frontier[result.labels.index(label)])
             print(f"    {label:<{label_w}}  {p:>6.1%}")
     print()
 
@@ -2652,12 +2728,18 @@ def _print_executive_summary(
     bundle: AnalysisBundle,
     *,
     item_singular: str = "template",
+    pareto: Optional[dict] = None,
 ) -> None:
     """Print a concise executive leaderboard after the stats-heavy blocks.
 
     Shows each template's significance group, mean score, bootstrap CI,
-    optional stability (when seed data is present), and a plain-language
-    verdict so the user can assess results at a glance without scrolling up.
+    optional stability (when seed data is present), optional Pareto status
+    (when ``compare(..., secondary=...)`` was passed -- see
+    ``_print_pareto_section``), and a plain-language verdict so the user can
+    assess results at a glance without scrolling up. The Pareto column
+    surfaces the secondary-metric verdict right next to the primary-metric
+    one, e.g. an entity that's "Likely best" on the primary metric but
+    "Dominated" once the secondary metric is considered.
     """
     labels = list(bundle.rank_dist.labels)
     n = len(labels)
@@ -2675,6 +2757,8 @@ def _print_executive_summary(
     # Seed variance for stability column (optional).
     sv = bundle.seed_variance
     has_stability = sv is not None
+    has_pareto = pareto is not None
+    pareto_statuses = pareto["statuses"] if has_pareto else None
 
     item_title = item_singular.capitalize()
     _print_subsection(f"--- Executive Summary ({item_title} leaderboard) ---")
@@ -2685,6 +2769,7 @@ def _print_executive_summary(
     mean_w = 6
     ci_w = 15  # e.g. "[0.950, 0.990]" = 14 chars + 1 padding
     stab_w = 16
+    pareto_w = max(len("Ambiguous"), len("Dominated"), len("Frontier"), len("Pareto"))
 
     # CI column header: Wilson CI when no bootstrap was used (binary data path).
     ci_col_header = "Wilson CI" if _uses_wilson_ci(bundle) else "CI"
@@ -2698,6 +2783,8 @@ def _print_executive_summary(
     ]
     if has_stability:
         header_parts.append(f"  {'Stability':<{stab_w}s}")
+    if has_pareto:
+        header_parts.append(f"  {'Pareto':<{pareto_w}s}")
     header_parts.append("  Verdict")
     header = "".join(header_parts)
     sep = "  " + "─" * (len(header) - 2)
@@ -2742,6 +2829,11 @@ def _print_executive_summary(
             else:
                 stab_str = "—"
             row += f"  {stab_str:<{stab_w}s}"
+
+        if has_pareto:
+            pareto_status = pareto_statuses.get(label)
+            pareto_str = pareto_status.status.capitalize() if pareto_status is not None else "—"
+            row += f"  {pareto_str:<{pareto_w}s}"
 
         row += f"  {verdict_str}"
         print(row)

--- a/evalstats/core/summary.py
+++ b/evalstats/core/summary.py
@@ -1519,6 +1519,8 @@ def _print_bundle_summary(
     # Executive summary leaderboard (near the end — immediately visible in terminal).
     print()
     _print_executive_summary(bundle, item_singular=item_singular, pareto=pareto)
+    if pareto is not None:
+        _print_pareto_callout(pareto, metric=metric)
 
     if guidance:
         _print_next_steps_guidance(
@@ -2623,6 +2625,21 @@ def _pareto_sorted_labels(pareto: dict) -> list[str]:
     )
 
 
+def _pareto_status_phrase(status: "ParetoStatus", *, verbose: bool = True) -> str:
+    """One-cell phrase combining a ParetoStatus's status word with its
+    detail (dominated_by / ambiguous_vs), e.g. "Dominated by gpt-4o" --
+    used by both the Pareto Front table (verbose=True, includes the
+    "(not confirmed)" qualifier) and the Executive Summary's narrower
+    Pareto column (verbose=False, drops it)."""
+    label = status.status.capitalize()
+    if status.status == "dominated":
+        return f"{label} by {', '.join(status.dominated_by)}"
+    if status.status == "ambiguous":
+        suffix = " (not confirmed)" if verbose else ""
+        return f"{label} vs {', '.join(status.ambiguous_vs)}{suffix}"
+    return label
+
+
 def _print_pareto_section(
     pareto: dict,
     *,
@@ -2653,12 +2670,16 @@ def _print_pareto_section(
 
     dir_label = "lower is better" if direction == "min" else "higher is better"
     metric_label = metric or "primary metric"
-    _print_subsection(f"--- Pareto Front ({metric_label} vs {secondary_col}, {dir_label}) ---")
+    _print_subsection(
+        f"--- {metric_label} vs. {secondary_col} Tradeoff "
+        f"(Pareto Front, {dir_label}) ---"
+    )
 
     sorted_labels = _pareto_sorted_labels(pareto)
     label_w = max((len(lbl) for lbl in result.labels), default=6)
     label_w = max(label_w, len("Entity"))
-    status_w = max(len("Ambiguous"), len("Dominated"), len("Frontier"))
+    phrases = {lbl: _pareto_status_phrase(statuses[lbl], verbose=True) for lbl in result.labels}
+    status_w = max([len("Status")] + [len(p) for p in phrases.values()])
     mean_w = 7
     ci_w = 17
 
@@ -2679,23 +2700,15 @@ def _print_pareto_section(
         header = (
             f"  {'Entity':<{label_w}}  {'Status':<{status_w}}  "
             f"{'Mean':>{mean_w}s} {'95% CI':<{ci_w}s}  "
-            f"{'Mean':>{mean_w}s} {'95% CI':<{ci_w}s}  Detail"
+            f"{'Mean':>{mean_w}s} {'95% CI':<{ci_w}s}"
         )
     else:
-        header = f"  {'Entity':<{label_w}}  {'Status':<{status_w}}  Detail"
+        header = f"  {'Entity':<{label_w}}  {'Status':<{status_w}}"
     print(header)
     print("  " + "-" * (len(header) - 2))
 
     for label in sorted_labels:
-        st = statuses[label]
-        status_disp = st.status.capitalize()
-        if st.status == "dominated":
-            detail = f"by {', '.join(st.dominated_by)}"
-        elif st.status == "ambiguous":
-            detail = f"vs {', '.join(st.ambiguous_vs)} (not confirmed)"
-        else:
-            detail = ""
-
+        status_disp = phrases[label]
         if have_stats:
             pi, si = prim_idx[label], sec_idx[label]
             p_mean = float(primary_rob.mean[pi])
@@ -2711,10 +2724,10 @@ def _print_pareto_section(
             print(
                 f"  {label:<{label_w}}  {status_disp:<{status_w}}  "
                 f"{p_mean:>{mean_w}.3g} {p_ci:<{ci_w}s}  "
-                f"{s_mean:>{mean_w}.3g} {s_ci:<{ci_w}s}  {detail}"
+                f"{s_mean:>{mean_w}.3g} {s_ci:<{ci_w}s}"
             )
         else:
-            print(f"  {label:<{label_w}}  {status_disp:<{status_w}}  {detail}")
+            print(f"  {label:<{label_w}}  {status_disp:<{status_w}}")
     print("  " + "-" * (len(header) - 2))
     if show_rank_probabilities:
         print("\n  P(Pareto-optimal):")
@@ -2759,6 +2772,10 @@ def _print_executive_summary(
     has_stability = sv is not None
     has_pareto = pareto is not None
     pareto_statuses = pareto["statuses"] if has_pareto else None
+    pareto_phrases: dict[str, str] = (
+        {lbl: _pareto_status_phrase(st, verbose=False) for lbl, st in pareto_statuses.items()}
+        if has_pareto else {}
+    )
 
     item_title = item_singular.capitalize()
     _print_subsection(f"--- Executive Summary ({item_title} leaderboard) ---")
@@ -2769,7 +2786,7 @@ def _print_executive_summary(
     mean_w = 6
     ci_w = 15  # e.g. "[0.950, 0.990]" = 14 chars + 1 padding
     stab_w = 16
-    pareto_w = max(len("Ambiguous"), len("Dominated"), len("Frontier"), len("Pareto"))
+    pareto_w = max([len("Pareto")] + [len(p) for p in pareto_phrases.values()]) if has_pareto else 0
 
     # CI column header: Wilson CI when no bootstrap was used (binary data path).
     ci_col_header = "Wilson CI" if _uses_wilson_ci(bundle) else "CI"
@@ -2831,14 +2848,53 @@ def _print_executive_summary(
             row += f"  {stab_str:<{stab_w}s}"
 
         if has_pareto:
-            pareto_status = pareto_statuses.get(label)
-            pareto_str = pareto_status.status.capitalize() if pareto_status is not None else "—"
+            pareto_str = pareto_phrases.get(label, "—")
             row += f"  {pareto_str:<{pareto_w}s}"
 
         row += f"  {verdict_str}"
         print(row)
 
     print(sep)
+    print()
+
+
+def _print_pareto_callout(pareto: dict, *, metric: Optional[str]) -> None:
+    """One-line bridge from the Executive Summary's primary-metric-only
+    leader to the Pareto Front's holistic view, e.g. "'gpt-4o' leads on
+    accuracy, but 'gpt-4o-mini' is a competitive tradeoff on latency_s" --
+    mirrors the existing "-> Evidence suggests a clear best option" callout
+    used after Pairwise Comparisons, giving a skimming reader the "so what"
+    without having to cross-reference the table above.
+    """
+    result = pareto["result"]
+    statuses = pareto["statuses"]
+    secondary_col = pareto["secondary_metric"]
+    if len(result.labels) < 2:
+        return
+
+    leader_idx = int(np.argmax(result.point_primary))
+    leader = result.labels[leader_idx]
+    metric_label = metric or "the primary metric"
+
+    other_frontier = [
+        lbl for lbl in _pareto_sorted_labels(pareto)
+        if lbl != leader and statuses[lbl].status == "frontier"
+    ]
+    if other_frontier:
+        names = ", ".join(f"'{lbl}'" for lbl in other_frontier)
+        is_are, article_or_plural = (
+            ("is", "a competitive tradeoff") if len(other_frontier) == 1
+            else ("are", "competitive tradeoffs")
+        )
+        print(
+            f"  -> '{leader}' leads on {metric_label}, but {names} {is_are} "
+            f"{article_or_plural} on {secondary_col} — see Pareto Front above."
+        )
+    else:
+        print(
+            f"  -> '{leader}' is also the best choice on {secondary_col} "
+            "— no real tradeoff here."
+        )
     print()
 
 

--- a/evalstats/core/summary.py
+++ b/evalstats/core/summary.py
@@ -2645,6 +2645,18 @@ def _pareto_status_color(status: str) -> str:
     return _YELLOW  # ambiguous
 
 
+def _join_names_capped(names: list[str], *, max_names: int = 2) -> str:
+    """Join entity names for a status phrase, capping how many get spelled
+    out -- an entity dominated by half a dozen others would otherwise blow
+    up the Status column (and the whole table) with a name list as wide as
+    the table itself. Mirrors the existing "Tied with N others as best"
+    capping already used in the Executive Summary's Verdict column."""
+    if len(names) <= max_names:
+        return ", ".join(names)
+    shown = ", ".join(names[:max_names])
+    return f"{shown} and {len(names) - max_names} more"
+
+
 def _pareto_status_phrase(status: "ParetoStatus", *, verbose: bool = True) -> str:
     """One-cell phrase combining a ParetoStatus's glyph with plain-language
     wording and its detail (dominated_by / ambiguous_vs), e.g.
@@ -2653,10 +2665,10 @@ def _pareto_status_phrase(status: "ParetoStatus", *, verbose: bool = True) -> st
     Executive Summary's narrower Pareto column (verbose=False, drops it)."""
     glyph = _pareto_status_glyph(status.status)
     if status.status == "dominated":
-        text = f"Worse than {', '.join(status.dominated_by)} on both"
+        text = f"Worse than {_join_names_capped(status.dominated_by)} on both"
     elif status.status == "ambiguous":
         suffix = " (not confirmed)" if verbose else ""
-        text = f"Unclear vs {', '.join(status.ambiguous_vs)}{suffix}"
+        text = f"Unclear vs {_join_names_capped(status.ambiguous_vs)}{suffix}"
     else:
         text = "Best trade-off"
     return f"{glyph} {text}"
@@ -2744,6 +2756,24 @@ def _print_pareto_scatter(
         f"{x_axis_label:^{max(width - 12, 4)}}"
         f"{x_max_str}"
     )
+
+    # The plot always stretches to fill its width/height regardless of how
+    # small the real spread is -- flag it explicitly when an axis's true
+    # range is tiny relative to its scale, so a reader doesn't mistake
+    # bootstrap noise blown up to fill the plot for a real difference.
+    def _near_degenerate(lo: float, hi: float) -> bool:
+        return (hi - lo) < 0.02 * max(abs(hi), abs(lo), 1e-9)
+
+    flat_axes = []
+    if _near_degenerate(x_min, x_max):
+        flat_axes.append(f"{secondary_col} ({x_min_str}–{x_max_str})")
+    if _near_degenerate(y_min, y_max):
+        flat_axes.append(f"{metric_label} ({y_min:.3g}–{y_max:.3g})")
+    if flat_axes:
+        print(
+            f"  Note: {' and '.join(flat_axes)} barely varies across entities "
+            "-- the spread above is mostly noise, not a real difference."
+        )
     print()
 
     legend_cells = []
@@ -2812,8 +2842,10 @@ def _print_pareto_section(
     _print_pareto_scatter(pareto, metric_label=metric_label)
 
     sorted_labels = _pareto_sorted_labels(pareto)
-    label_w = max((len(lbl) for lbl in result.labels), default=6)
-    label_w = max(label_w, len("Entity"))
+    # Capped the same way every other table's entity/model column is
+    # (see e.g. _print_executive_summary's tpl_w) -- long entity names would
+    # otherwise stretch this table arbitrarily wide.
+    label_w = min(28, max(len("Entity"), max((len(lbl) for lbl in result.labels), default=6)))
     phrases = {lbl: _pareto_status_phrase(statuses[lbl], verbose=True) for lbl in result.labels}
     status_w = max([len("Status")] + [len(p) for p in phrases.values()])
     mean_w = 7
@@ -2860,12 +2892,12 @@ def _print_pareto_section(
                 if secondary_rob.ci_low is not None else "--"
             )
             print(
-                f"  {label:<{label_w}}  {status_str}  "
+                f"  {_truncate_label(label, label_w):<{label_w}}  {status_str}  "
                 f"{p_mean:>{mean_w}.3g} {p_ci:<{ci_w}s}  "
                 f"{s_mean:>{mean_w}.3g} {s_ci:<{ci_w}s}"
             )
         else:
-            print(f"  {label:<{label_w}}  {status_str}")
+            print(f"  {_truncate_label(label, label_w):<{label_w}}  {status_str}")
     print("  " + "-" * (len(header) - 2))
     if show_rank_probabilities:
         print()
@@ -2876,7 +2908,7 @@ def _print_pareto_section(
             p = float(result.p_frontier[result.labels.index(label)])
             color = _p_best_color(p)
             reset = _RESET if color else ""
-            print(f"    {label:<{label_w}}  {p:>6.1%} {color}{_ratio_bar(p, width=bar_w)}{reset}")
+            print(f"    {_truncate_label(label, label_w):<{label_w}}  {p:>6.1%} {color}{_ratio_bar(p, width=bar_w)}{reset}")
     print()
 
 

--- a/evalstats/core/summary.py
+++ b/evalstats/core/summary.py
@@ -2945,6 +2945,9 @@ def _print_executive_summary(
 
     # Significance group letters via CD groups.
     label_to_group = _assign_significance_groups(bundle.pairwise, labels_sorted)
+    verdict_by_label = {
+        label: _exec_verdict(label, label_to_group, labels_sorted) for label in labels_sorted
+    }
 
     # Seed variance for stability column (optional).
     sv = bundle.seed_variance
@@ -2988,10 +2991,22 @@ def _print_executive_summary(
     ]
     if has_stability:
         header_parts.append(f"  {'Stability':<{stab_w}s}")
-    if has_pareto:
-        header_parts.append(f"  {tradeoff_header:<{pareto_w}s}")
     verdict_header = f"On {metric or 'primary metric'}" if has_pareto else "Verdict"
-    header_parts.append(f"  {verdict_header}")
+    # Only needs padding when it's no longer the last (unpadded) column,
+    # i.e. once Trade-off follows it -- computed from the actual verdict
+    # strings, which vary a lot ("Likely best" vs. "Tied with X as best").
+    verdict_w = (
+        max([len(verdict_header)] + [len(v) for v in verdict_by_label.values()])
+        if has_pareto else 0
+    )
+    if has_pareto:
+        # "On {metric}" first (echoes the Mean/CI columns just shown), then
+        # "Trade-off vs {secondary}" -- reads as "here's the primary-metric
+        # call, and here's how that changes once the other axis counts too."
+        header_parts.append(f"  {verdict_header:<{verdict_w}s}")
+        header_parts.append(f"  {tradeoff_header}")
+    else:
+        header_parts.append(f"  {verdict_header}")
     header = "".join(header_parts)
     sep = "  " + "─" * (len(header) - 2)
     print(header)
@@ -3006,19 +3021,20 @@ def _print_executive_summary(
         ci_str = f"[{ci_lo:.3f}, {ci_hi:.3f}]"
 
         group = label_to_group.get(label, "?")
-        verdict = _exec_verdict(label, label_to_group, labels_sorted)
+        verdict = verdict_by_label[label]
 
         # Pre-format fixed-width parts, then optionally wrap with ANSI.
         plain_label = f"{_truncate_label(label, tpl_w):<{tpl_w}s}"
         plain_grp = f"{group:^{grp_w}s}"
+        plain_verdict = f"{verdict:<{verdict_w}s}" if has_pareto else verdict
         if group == "#1" and _ANSI:
             label_str = f"{_BOLD}{_BRIGHT_GREEN}{plain_label}{_RESET}"
             grp_str = f"{_BOLD}{_BRIGHT_GREEN}{plain_grp}{_RESET}"
-            verdict_str = f"{_BRIGHT_GREEN}{verdict}{_RESET}"
+            verdict_str = f"{_BRIGHT_GREEN}{plain_verdict}{_RESET}"
         else:
             label_str = plain_label
             grp_str = plain_grp
-            verdict_str = verdict
+            verdict_str = plain_verdict
 
         row = (
             f"  {label_str}"
@@ -3036,8 +3052,12 @@ def _print_executive_summary(
                 stab_str = "—"
             row += f"  {stab_str:<{stab_w}s}"
 
+        # "On {metric}" (verdict) first, then "Trade-off vs {secondary}" --
+        # matches the header order above.
+        row += f"  {verdict_str}"
+
         if has_pareto:
-            pareto_plain = f"{pareto_phrases.get(label, '—'):<{pareto_w}s}"
+            pareto_plain = pareto_phrases.get(label, "—")
             pareto_color = (
                 _pareto_status_color(pareto_statuses[label].status)
                 if label in pareto_statuses else ""
@@ -3045,7 +3065,6 @@ def _print_executive_summary(
             pareto_str = f"{pareto_color}{pareto_plain}{_RESET}" if pareto_color else pareto_plain
             row += f"  {pareto_str}"
 
-        row += f"  {verdict_str}"
         print(row)
 
     print(sep)

--- a/evalstats/core/summary.py
+++ b/evalstats/core/summary.py
@@ -1518,7 +1518,7 @@ def _print_bundle_summary(
 
     # Executive summary leaderboard (near the end — immediately visible in terminal).
     print()
-    _print_executive_summary(bundle, item_singular=item_singular, pareto=pareto)
+    _print_executive_summary(bundle, item_singular=item_singular, pareto=pareto, metric=metric)
     if pareto is not None:
         _print_pareto_callout(pareto, metric=metric)
 
@@ -2917,17 +2917,21 @@ def _print_executive_summary(
     *,
     item_singular: str = "template",
     pareto: Optional[dict] = None,
+    metric: Optional[str] = None,
 ) -> None:
     """Print a concise executive leaderboard after the stats-heavy blocks.
 
     Shows each template's significance group, mean score, bootstrap CI,
-    optional stability (when seed data is present), optional Pareto status
-    (when ``compare(..., secondary=...)`` was passed -- see
+    optional stability (when seed data is present), optional Trade-off
+    status (when ``compare(..., secondary=...)`` was passed -- see
     ``_print_pareto_section``), and a plain-language verdict so the user can
-    assess results at a glance without scrolling up. The Pareto column
+    assess results at a glance without scrolling up. The Trade-off column
     surfaces the secondary-metric verdict right next to the primary-metric
     one, e.g. an entity that's "Likely best" on the primary metric but
-    "Worse than X on both" once the secondary metric is considered.
+    "Worse than X on both" once the secondary metric is considered -- and
+    when Trade-off is shown, the last column is relabeled "On {metric}"
+    (instead of the bare "Verdict") so it reads as scoped to the primary
+    metric alone, rather than as the final word once a second axis exists.
     """
     labels = list(bundle.rank_dist.labels)
     n = len(labels)
@@ -2977,7 +2981,8 @@ def _print_executive_summary(
         header_parts.append(f"  {'Stability':<{stab_w}s}")
     if has_pareto:
         header_parts.append(f"  {'Trade-off':<{pareto_w}s}")
-    header_parts.append("  Verdict")
+    verdict_header = f"On {metric or 'primary metric'}" if has_pareto else "Verdict"
+    header_parts.append(f"  {verdict_header}")
     header = "".join(header_parts)
     sep = "  " + "─" * (len(header) - 2)
     print(header)

--- a/evalstats/core/summary.py
+++ b/evalstats/core/summary.py
@@ -2831,7 +2831,7 @@ def _print_pareto_section(
     dir_label = "lower is better" if direction == "min" else "higher is better"
     metric_label = metric or "primary metric"
     _print_subsection(
-        f"--- {metric_label} vs. {secondary_col} Tradeoff "
+        f"--- {metric_label} vs. {secondary_col} Trade-off "
         f"(Pareto Front, {dir_label}) ---"
     )
     print(
@@ -2961,7 +2961,7 @@ def _print_executive_summary(
     mean_w = 6
     ci_w = 15  # e.g. "[0.950, 0.990]" = 14 chars + 1 padding
     stab_w = 16
-    pareto_w = max([len("Pareto")] + [len(p) for p in pareto_phrases.values()]) if has_pareto else 0
+    pareto_w = max([len("Trade-off")] + [len(p) for p in pareto_phrases.values()]) if has_pareto else 0
 
     # CI column header: Wilson CI when no bootstrap was used (binary data path).
     ci_col_header = "Wilson CI" if _uses_wilson_ci(bundle) else "CI"
@@ -2976,7 +2976,7 @@ def _print_executive_summary(
     if has_stability:
         header_parts.append(f"  {'Stability':<{stab_w}s}")
     if has_pareto:
-        header_parts.append(f"  {'Pareto':<{pareto_w}s}")
+        header_parts.append(f"  {'Trade-off':<{pareto_w}s}")
     header_parts.append("  Verdict")
     header = "".join(header_parts)
     sep = "  " + "─" * (len(header) - 2)
@@ -3041,7 +3041,7 @@ def _print_executive_summary(
 def _print_pareto_callout(pareto: dict, *, metric: Optional[str]) -> None:
     """One-line bridge from the Executive Summary's primary-metric-only
     leader to the Pareto Front's holistic view, e.g. "'gpt-4o' leads on
-    accuracy, but 'gpt-4o-mini' is a competitive tradeoff on latency_s" --
+    accuracy, but 'gpt-4o-mini' is a competitive trade-off on latency_s" --
     mirrors the existing "-> Evidence suggests a clear best option" callout
     used after Pairwise Comparisons, giving a skimming reader the "so what"
     without having to cross-reference the table above.
@@ -3063,8 +3063,8 @@ def _print_pareto_callout(pareto: dict, *, metric: Optional[str]) -> None:
     if other_frontier:
         names = ", ".join(f"'{lbl}'" for lbl in other_frontier)
         is_are, article_or_plural = (
-            ("is", "a competitive tradeoff") if len(other_frontier) == 1
-            else ("are", "competitive tradeoffs")
+            ("is", "a competitive trade-off") if len(other_frontier) == 1
+            else ("are", "competitive trade-offs")
         )
         print(
             f"  -> '{leader}' leads on {metric_label}, but {names} {is_are} "
@@ -3073,7 +3073,7 @@ def _print_pareto_callout(pareto: dict, *, metric: Optional[str]) -> None:
     else:
         print(
             f"  -> '{leader}' is also the best choice on {secondary_col} "
-            "— no real tradeoff here."
+            "— no real trade-off here."
         )
     print()
 

--- a/examples/compare_pareto_secondary_metric.py
+++ b/examples/compare_pareto_secondary_metric.py
@@ -1,0 +1,94 @@
+"""Uncertainty-aware Pareto-front analysis: compare(secondary=...).
+
+A developer is choosing among 5 models and cares about both accuracy and
+latency. A naive Pareto front on point estimates alone would call a
+"dominates" verdict any time one model's mean beats another's on both axes
+-- even when the underlying per-item data can't actually support that claim.
+compare(secondary=...) instead jointly bootstraps both metrics (a shared
+per-item resample, not two independent marginal bootstraps) so dominance
+calls are only made when the data backs them up, and reports a calibrated
+three-state verdict per model: "frontier", "dominated", or "ambiguous"
+(point estimate looks dominated, but there isn't enough evidence to confirm
+it -- the case a naive point-estimate-only Pareto front would silently
+misreport as a clean frontier member).
+
+Ground-truth shape used to generate the data below:
+  gpt-4o          high accuracy, moderate latency
+  gpt-4o-mini     lower accuracy, very low latency      -- a real tradeoff
+  claude-sonnet   worse accuracy AND worse latency than gpt-4o -- dominated
+  claude-haiku    accuracy/latency both slightly behind gpt-4o-mini, but
+                  noisy enough at this N that it isn't a confident call
+                  -- "ambiguous", not "dominated"
+  llama-70b       mid accuracy, mid latency              -- a real tradeoff
+
+Usage:
+    python examples/compare_pareto_secondary_metric.py
+"""
+
+import numpy as np
+import pandas as pd
+
+import evalstats as es
+
+
+rng = np.random.default_rng(7)
+
+N_ITEMS = 120
+
+ACCURACY = {
+    "gpt-4o": 0.85,
+    "gpt-4o-mini": 0.72,
+    "claude-sonnet": 0.80,
+    "claude-haiku": 0.705,
+    "llama-70b": 0.78,
+}
+LATENCY_S = {  # lower is better
+    "gpt-4o": 2.0,
+    "gpt-4o-mini": 0.4,
+    "claude-sonnet": 2.6,
+    "claude-haiku": 0.42,
+    "llama-70b": 1.1,
+}
+
+rows = []
+for model, acc in ACCURACY.items():
+    lat = LATENCY_S[model]
+    for i in range(N_ITEMS):
+        rows.append({
+            "model": model,
+            "item": f"q{i:03d}",
+            "accuracy": float(np.clip(rng.normal(acc, 0.09), 0, 1)),
+            "latency_s": float(np.clip(rng.normal(lat, 0.35), 0.05, None)),
+        })
+df = pd.DataFrame(rows)
+
+evaldata = es.load_from(df, col_map={"model": "model", "item": "item"})
+
+result = es.compare(
+    evaldata,
+    factors="model",
+    metric="accuracy",
+    secondary={"latency_s": "min"},
+    rng=np.random.default_rng(42),
+    show_rank_probabilities=True,  # also print the continuous P(Pareto-optimal)
+)
+
+print("=" * 70)
+print("result.summary() -- full comparison, including the Pareto Front block")
+print("=" * 70)
+result.summary(top_pairwise=4)
+
+print("=" * 70)
+print("Programmatic access")
+print("=" * 70)
+print("result.pareto_status:")
+for label, status in result.pareto_status.items():
+    print(f"  {label:<15s} {status.status:<10s} dominated_by={status.dominated_by} ambiguous_vs={status.ambiguous_vs}")
+print()
+print("result.pareto_frontier_probability (P(Pareto-optimal) per model):")
+for label, p in result.pareto_frontier_probability.items():
+    print(f"  {label:<15s} {p:.1%}")
+print()
+print("result.to_dict()['pareto']:")
+import json
+print(json.dumps(result.to_dict(show_rank_probabilities=True)["pareto"], indent=2))

--- a/simulations/harness/cases/ppi_real.py
+++ b/simulations/harness/cases/ppi_real.py
@@ -922,6 +922,44 @@ def _run_real_wmt_paired_bias_cell(
     return dict(out)
 
 
+def _run_real_paired_bias_cell(
+    corpus: RealJudgeBiasCorpus, methods: list[str], n: int, label_frac: float,
+    judge_a: str, judge_b: str, n_reps: int, n_boot: int, seed: int,
+) -> dict[str, list[tuple[float, float, float, float]]]:
+    """Tuple-collecting sibling of _run_real_paired_cell, using the SAME
+    generate_real_paired_null_cell (same items read through two DIFFERENT
+    judges, so the true paired difference is EXACTLY 0 by construction -- no
+    gold-reference estimation needed, unlike _run_real_wmt_paired_bias_
+    cell's genuine two-condition data). Exists because TANGO is a genuine
+    point-estimate/CI construction (a Wilson-style score interval for the
+    paired binary discordant-pair-rate difference -- see
+    evalstats.tests._ppi_paired_tango's docstring) restricted to binary
+    corpora by _paired_methods_for, but _run_real_paired_cell only ever
+    reports corrected/uncorrected REJECTION COUNTS (a Type-I check) -- it
+    never had anywhere to report (estimate, ci_low, ci_high, llm_estimate)
+    tuples, so a binary corpus like arena had no path into the bias/
+    coverage view (print_ppi_effect_report / ci_methods_comparison_real.png)
+    even though it has exactly the paired binary data Tango needs. Currently
+    only TANGO uses this; null_value is always 0.0 for every test reachable
+    here (see run()'s _consume)."""
+    rng = np.random.default_rng(seed)
+    out: dict[str, list[tuple[float, float, float, float]]] = defaultdict(list)
+
+    for _ in range(n_reps):
+        llm_x, llm_y, lab_x, lab_y = generate_real_paired_null_cell(corpus, rng, n, label_frac, judge_a, judge_b)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            if TANGO.name in methods:
+                try:
+                    r = _ppi_paired_tango(llm_x, llm_y, lab_x, lab_y, _ALPHA)
+                    out[TANGO.name].append((r.estimate, r.ci_low, r.ci_high, r.llm_estimate))
+                except Exception:
+                    pass
+
+    return dict(out)
+
+
 _REAL_CORPORA: list[RealJudgeBiasCorpus] = []
 """Set by run() right before creating the worker Pool (fork context), so
 worker processes inherit it via copy-on-write instead of the (potentially
@@ -939,13 +977,13 @@ been collected yet (see run()'s try/except around load_real_wmt_paired_corpus)."
 
 
 def _run_ppi_real_cell_worker(args: tuple) -> dict:
-    """Runs ONE (single|twogroup|paired|omnibus_independent|omnibus_repeated|
-    wmt_paired_bias|twogroup_power|omnibus_independent_power|
-    wmt_paired_power) cell and returns everything run() needs to fold it
-    into effect_results/twogroup_results/paired_results/omnibus_results/
-    power_results, with no dependency on the original work-item's position
-    -- required since pool.imap_unordered does not preserve submission
-    order."""
+    """Runs ONE (single|twogroup|paired|paired_bias|omnibus_independent|
+    omnibus_repeated|wmt_paired_bias|twogroup_power|
+    omnibus_independent_power|wmt_paired_power) cell and returns everything
+    run() needs to fold it into effect_results/twogroup_results/
+    paired_results/omnibus_results/power_results, with no dependency on the
+    original work-item's position -- required since pool.imap_unordered
+    does not preserve submission order."""
     check_type, corpus_idx, name, dataset, methods, n, label_frac, judge_or_group, n_reps, n_boot, seed = args
 
     if check_type in ("wmt_paired_bias", "wmt_paired_power"):
@@ -971,6 +1009,14 @@ def _run_ppi_real_cell_worker(args: tuple) -> dict:
         return {
             "check_type": check_type, "name": name, "dataset": dataset, "n": n,
             "corpus_mean": corpus.corpus_mean, "samples_by_test": samples_by_test,
+        }
+
+    if check_type == "paired_bias":
+        judge_a, judge_b = judge_or_group
+        samples_by_test = _run_real_paired_bias_cell(corpus, methods, n, label_frac, judge_a, judge_b, n_reps, n_boot, seed)
+        return {
+            "check_type": check_type, "name": name, "dataset": dataset, "n": n,
+            "samples_by_test": samples_by_test,
         }
 
     if check_type in ("omnibus_independent", "omnibus_repeated", "omnibus_independent_power"):
@@ -1929,6 +1975,24 @@ def run(args: argparse.Namespace) -> CaseResult:
                                     n, label_frac, (judge_a, judge_b), args.reps, args.ppi_n_boot, seed_counter,
                                 ))
 
+                            # Binary-only bias/coverage sibling of the check
+                            # above: TANGO is a genuine point-estimate/CI
+                            # construction, but _run_real_paired_cell only
+                            # ever reports corrected/uncorrected rejection
+                            # COUNTS (a Type-I check), so Tango had no path
+                            # into the bias/coverage view even on a binary
+                            # corpus like arena that has exactly the paired
+                            # binary data it needs. Reuses the SAME exact
+                            # null (generate_real_paired_null_cell) as the
+                            # Type-I check above -- see
+                            # _run_real_paired_bias_cell.
+                            if not args.no_paired_check and corpus.eval_type == "binary":
+                                seed_counter += 1
+                                work_items.append((
+                                    "paired_bias", corpus_idx, name, corpus.dataset, [TANGO.name],
+                                    n, label_frac, (judge_a, judge_b), args.reps, args.ppi_n_boot, seed_counter,
+                                ))
+
                     # omnibus-independent/omnibus-repeated both need judge
                     # TRIPLES (cross-judge, same reasoning as twogroup/paired
                     # above, just extended to 3 groups/conditions), so both
@@ -2027,6 +2091,22 @@ def run(args: argparse.Namespace) -> CaseResult:
                     effect_results.append(PPIEffectResult(
                         name=result["name"], tag=f"real_{result['dataset']}", test=t, n=result["n"], n_samples=n_ok,
                         null_value=null_value, mean_bias=bias_mean, bias_z=z,
+                        coverage=coverage, mean_ci_width=mean_width, uncorrected_bias_z=unc_z,
+                    ))
+            elif ct == "paired_bias":
+                # Same PPIEffectResult shape as "single"/"wmt_paired_bias"
+                # above, but null_value is always 0.0 for every test reached
+                # here -- generate_real_paired_null_cell is an EXACT null by
+                # construction (same items, two different judges), unlike
+                # wmt_paired_bias's genuine two-condition paired data.
+                for t, samples in result["samples_by_test"].items():
+                    bias_mean, z, coverage, mean_width, n_ok = _effect_cell_stats(samples, 0.0)
+                    if n_ok == 0:
+                        continue
+                    unc_z = _uncorrected_bias_z(samples, 0.0)
+                    effect_results.append(PPIEffectResult(
+                        name=result["name"], tag=f"real_{result['dataset']}", test=t, n=result["n"], n_samples=n_ok,
+                        null_value=0.0, mean_bias=bias_mean, bias_z=z,
                         coverage=coverage, mean_ci_width=mean_width, uncorrected_bias_z=unc_z,
                     ))
             else:

--- a/simulations/replot_alignment_sweep_wide_buckets.py
+++ b/simulations/replot_alignment_sweep_wide_buckets.py
@@ -1,0 +1,185 @@
+"""One-off variant of save_ppi_alignment_sweep_plot (see
+simulations/harness/cases/pvalues.py) for the paper's main-text figure
+(fig:corr-likert-weighted-judge-bias), which is placed at full printed page
+width via \\includegraphics[width=\\linewidth]{...} in a figure* environment.
+
+The original plot buckets alignment into 10-point-wide (0.10) bands, which
+for likert/weighted-kappa yields ~10 side-by-side panels -- fine on screen,
+but each panel's title/tick/legend text becomes illegibly small once shrunk
+to fit a printed page column. This script re-derives the SAME view straight
+from an already-saved *_alignment_{mcar,mnar}_ppi_alignment_sweep_results.csv
+(no simulation rerun) using:
+
+  - 20-point-wide (0.20) alignment buckets instead of 10-point, so there are
+    only ~5 panels instead of ~10 -- each one twice as wide.
+  - Substantially larger fonts throughout (title/suptitle/tick/axis/legend),
+    sized for the panel count/width this produces.
+
+Bucket regime split (no_bias / bias_present, moderate-bias excluded) is
+recomputed via the CURRENT _alignment_regime, not read from the CSV's own
+"regime" column -- that column was written by an earlier version of the
+sweep for some pre-2026-08-03 runs and may predate the moderate-bias-
+exclusion fix (see _alignment_regime's docstring in pvalues.py).
+
+Usage:
+  .venv/bin/python -m simulations.replot_alignment_sweep_wide_buckets \\
+      simulations/out/factorial_alignment_recheck_20260803_135105/pvalues_ppi_factorial_reps30_20260803_135106_alignment_mcar_ppi_alignment_sweep_results.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import warnings
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from simulations.harness.cases.pvalues import (
+    _alignment_regime,
+    _kappa_band,
+    _metric_pct,
+    _ppi_wilson_interval,
+)
+
+BUCKET_WIDTH = 20  # 0.20 on the 0-1 kappa scale (vs. the original's 10 / 0.10)
+
+
+def _bucket(pct: float, width: int = BUCKET_WIDTH) -> tuple[int, str]:
+    lo = int(pct // width) * width
+    lo = max(0, min(lo, 100 - width))
+    return lo, f"{lo}-{lo + width}%"
+
+
+def load_rows(csv_path: str, eval_type: str, metric: str) -> list[dict]:
+    with open(csv_path, newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    out = []
+    for r in rows:
+        if r["eval_type"] != eval_type or not r[metric]:
+            continue
+        regime = _alignment_regime(r["bias_label"])
+        if regime == "excluded":
+            continue
+        out.append({
+            "metric_val": float(r[metric]),
+            "regime": regime,
+            "n_reps": int(r["n_reps"]),
+            "rejects_llm_only": round(float(r["rate_llm_only"]) * int(r["n_reps"])),
+            "rejects_ppi": round(float(r["rate_ppi"]) * int(r["n_reps"])),
+        })
+    return out
+
+
+def plot(rows: list[dict], *, eval_type: str, display_label: str, symbol: str, alpha: float, out_path: str) -> str:
+    if not rows:
+        raise ValueError("No rows to plot.")
+    bar_width = 0.35
+    group_gap = 0.5
+    regimes = ("no_bias", "bias_present")
+    arm_colors = {"llm_only": "#e7298a", "ppi": "#FFD400"}
+    arm_edgecolors = {"llm_only": "none", "ppi": "#8a6d00"}
+    arm_labels = {"llm_only": "uncorrected", "ppi": "PPI-corrected"}
+
+    # A figure this wide (in matplotlib inches) gets shrunk hard when placed
+    # at \linewidth in the paper -- what determines the PRINTED font size is
+    # the fontsize/figure-width-in-inches ratio, not the raw point values
+    # below. These are large enough, relative to PANEL_WIDTH_IN further down,
+    # to still read at print size after that shrink (tuned against an actual
+    # ACM sigconf two-column figure* render, not just the on-screen preview).
+    FS_TICK = 19
+    FS_TITLE = 23
+    FS_SUPTITLE = 23
+    FS_YLABEL = 23
+    FS_LEGEND = 21
+    FS_YTICKS = 19
+
+    # Locally line-broken AND shortened (vs. _PPI_ALIGNMENT_REGIME_LABEL's
+    # single-line "no judge bias (noise only)") -- at this figure's larger
+    # tick font size and narrower (see PANEL_WIDTH_IN) panels, even the
+    # two-line break alone is wide enough to collide with the adjacent
+    # group's label; dropping "judge" keeps the longest line short enough.
+    # Purely a presentation choice for THIS print-width plot, not a change
+    # to the shared regime label text itself.
+    regime_label_lines = {"no_bias": "no bias\n(noise only)", "bias_present": "bias present"}
+
+    buckets = sorted({_bucket(_metric_pct(r["metric_val"])) for r in rows})
+
+    # Narrower than the earlier 4.6in/panel: since \includegraphics[width=
+    # \linewidth] normalizes the FINAL printed width regardless of this
+    # figure's own inch size, a narrower source figure at the SAME font
+    # points raises the printed font size (see FS_* comment above).
+    PANEL_WIDTH_IN = 3.5
+    fig, axes = plt.subplots(1, len(buckets), figsize=(PANEL_WIDTH_IN * len(buckets), 5.4), squeeze=False, sharey=True)
+    for col, (lo, label) in enumerate(buckets):
+        ax = axes[0][col]
+        ax.axhline(
+            alpha, color="black", ls="--", lw=1.6, alpha=0.6, zorder=1,
+            label="nominal α" if col == 0 else None,
+        )
+        xticks, xticklabels = [], []
+        for gi, regime in enumerate(regimes):  # ALWAYS both, even if empty
+            cells = [r for r in rows if _bucket(_metric_pct(r["metric_val"])) == (lo, label) and r["regime"] == regime]
+            n_reps_tot = sum(c["n_reps"] for c in cells)
+            for ai, arm in enumerate(("llm_only", "ppi")):
+                x = gi * (2 * bar_width + group_gap) + ai * bar_width
+                if n_reps_tot == 0:
+                    continue
+                rejects_tot = sum(c[f"rejects_{arm}"] for c in cells)
+                rate = rejects_tot / n_reps_tot
+                lo_ci, hi_ci = _ppi_wilson_interval(rejects_tot, n_reps_tot)
+                ax.bar(
+                    x, rate, width=bar_width, color=arm_colors[arm], edgecolor=arm_edgecolors[arm],
+                    linewidth=1.2, zorder=2,
+                    label=arm_labels[arm] if (col == 0 and gi == 0) else None,
+                )
+                ax.errorbar(
+                    x, rate, yerr=[[max(0.0, rate - lo_ci)], [max(0.0, hi_ci - rate)]],
+                    fmt="none", ecolor="black", elinewidth=1.4, capsize=4, zorder=4,
+                )
+            mid = gi * (2 * bar_width + group_gap) + bar_width / 2
+            xticks.append(mid)
+            xticklabels.append(f"{regime_label_lines[regime]}\n(n={len(cells)})")
+        ax.set_xticks(xticks)
+        ax.set_xticklabels(xticklabels, fontsize=FS_TICK)
+        ax.set_xlim(-0.3, (2 * bar_width + group_gap) * len(regimes) - group_gap + 0.05)
+        ax.set_ylim(0.0, 1.05)
+        ax.tick_params(axis="y", labelsize=FS_YTICKS)
+        band = _kappa_band((lo + BUCKET_WIDTH / 2) / 100.0)
+        ax.set_title(f"{symbol}={lo / 100:.1f}-{(lo + BUCKET_WIDTH) / 100:.1f}\n({band})", fontsize=FS_TITLE)
+        if col == 0:
+            ax.set_ylabel("False positive rate", fontsize=FS_YLABEL)
+        ax.grid(axis="y", alpha=0.25, lw=1.0, zorder=0)
+    handles, labels = axes[0][0].get_legend_handles_labels()
+    fig.legend(handles, labels, loc="center left", bbox_to_anchor=(1.0, 0.5), fontsize=FS_LEGEND, frameon=True)
+    fig.suptitle(
+        f"{eval_type.capitalize()}: False-Positive Rate by Judge-Human Alignment ({display_label})",
+        fontsize=FS_SUPTITLE, y=0.99,
+    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=r".*tight_layout.*", category=UserWarning)
+        fig.tight_layout(rect=(0, 0, 1, 0.95))
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("csv_path", help="Path to a *_alignment_{mcar,mnar}_ppi_alignment_sweep_results.csv")
+    parser.add_argument("--out", default=None, help="Output image path")
+    parser.add_argument("--alpha", type=float, default=0.05)
+    args = parser.parse_args()
+
+    rows = load_rows(args.csv_path, eval_type="likert", metric="weighted_kappa")
+    csv_stem = Path(args.csv_path).stem.removesuffix("_ppi_alignment_sweep_results")
+    out_path = args.out or str(
+        Path(args.csv_path).parent / "plots" / f"{csv_stem}_likert_weighted_kappa_wide_buckets.png"
+    )
+    saved = plot(rows, eval_type="likert", display_label="weighted κ", symbol="κ", alpha=args.alpha, out_path=out_path)
+    print(f"Saved: {saved}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -542,6 +542,49 @@ def test_executive_summary_verdict_header_scoped_to_metric_when_pareto_shown():
     assert "On score" not in header_line2
 
 
+def test_executive_summary_tradeoff_header_names_secondary_metric():
+    """The Trade-off column header should name the secondary metric too
+    (paired with "On {metric}"), so the two headers alone state both axes
+    without needing the Pareto section above -- and truncate a long
+    secondary column name rather than blowing out the table width."""
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=64)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(65),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    header_line = buf.getvalue()[buf.getvalue().index("Executive Summary"):].splitlines()[1]
+    assert "Trade-off vs latency_ms" in header_line
+
+    # Long secondary column name gets truncated, not left to stretch the table.
+    long_col = "average_response_latency_milliseconds_p99"
+    rng2 = _rng(66)
+    rows = [
+        {
+            "model": m, "item": f"q{i}",
+            "score": float(np.clip(rng2.normal(_ACC[m], 0.08), 0, 1)),
+            long_col: float(np.clip(rng2.normal(_LAT[m], 0.4), 0.05, None)),
+        }
+        for m in _MODELS for i in range(150)
+    ]
+    evaldata2 = es.load_from(pd.DataFrame(rows), col_map={"model": "model", "item": "item"})
+    result2 = es.compare(
+        evaldata2, factors="model", metric="score",
+        secondary={long_col: "min"}, rng=_rng(67),
+    )
+    buf2 = io.StringIO()
+    with redirect_stdout(buf2):
+        result2.summary()
+    header_line2 = buf2.getvalue()[buf2.getvalue().index("Executive Summary"):].splitlines()[1]
+    assert long_col not in header_line2
+    assert "Trade-off vs average" in header_line2
+
+
 def test_pareto_status_phrase_merges_status_and_detail():
     from evalstats.core.summary import _pareto_status_phrase
     from evalstats.core.pareto import ParetoStatus

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -511,6 +511,37 @@ def test_executive_summary_no_pareto_column_without_secondary():
     assert "Trade-off" not in exec_section.splitlines()[1]
 
 
+def test_executive_summary_verdict_header_scoped_to_metric_when_pareto_shown():
+    """"Verdict" alone would read as the final word once a second axis
+    (Trade-off) exists in the same row -- it should be relabeled to make
+    clear it's scoped to the primary metric only. Without secondary=, the
+    plain "Verdict" header is unambiguous and should stay as-is."""
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=60)
+    with_secondary = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(61),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        with_secondary.summary()
+    out = buf.getvalue()
+    header_line = out[out.index("Executive Summary"):].splitlines()[1]
+    assert "On score" in header_line
+    assert "Verdict" not in header_line
+
+    without_secondary = es.compare(evaldata, factors="model", metric="score", rng=_rng(63))
+    buf2 = io.StringIO()
+    with redirect_stdout(buf2):
+        without_secondary.summary()
+    out2 = buf2.getvalue()
+    header_line2 = out2[out2.index("Executive Summary"):].splitlines()[1]
+    assert "Verdict" in header_line2
+    assert "On score" not in header_line2
+
+
 def test_pareto_status_phrase_merges_status_and_detail():
     from evalstats.core.summary import _pareto_status_phrase
     from evalstats.core.pareto import ParetoStatus

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -593,6 +593,83 @@ def test_pareto_status_glyphs_are_distinct():
     assert len(glyphs) == 3
 
 
+def test_join_names_capped_truncates_long_dominator_lists():
+    from evalstats.core.summary import _join_names_capped
+
+    assert _join_names_capped(["A"]) == "A"
+    assert _join_names_capped(["A", "B"]) == "A, B"
+    # Entities dominated by many others would otherwise blow up the Status
+    # column (and the whole table) with a name list as wide as the table.
+    assert _join_names_capped(["A", "B", "C"]) == "A, B and 1 more"
+    assert _join_names_capped(["A", "B", "C", "D", "E"]) == "A, B and 3 more"
+
+
+def test_pareto_table_entity_column_capped_for_long_names():
+    import io
+    from contextlib import redirect_stdout
+
+    models = [
+        "gpt-4o-2024-11-20-high-reasoning-effort-and-then-some-more-text",
+        "claude-opus-4-5-extended-thinking-mode-with-a-very-long-suffix",
+    ]
+    acc = {models[0]: 0.85, models[1]: 0.70}
+    lat = {models[0]: 2.0, models[1]: 0.5}
+    evaldata = _make_evaldata(models, acc, lat, seed=54)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(55),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    pareto_section = out[out.index("Pareto Front"):out.index("Executive Summary")]
+    # No line in the table should run away to the full untruncated name length.
+    table_lines = [
+        l for l in pareto_section.splitlines()
+        if l.strip().startswith(models[0][:10]) or l.strip().startswith(models[1][:10])
+    ]
+    assert table_lines
+    for line in table_lines:
+        assert len(line) < len(models[0]) + 40
+
+
+def test_pareto_scatter_flags_near_degenerate_axis():
+    import io
+    from contextlib import redirect_stdout
+
+    # All entities share the ~same latency (tight noise, same true mean) --
+    # the secondary axis is essentially flat, and the scatterplot should say
+    # so rather than silently stretching sampling noise to fill the plot
+    # width. Built directly (not via _make_evaldata) because that helper's
+    # fixed noise std isn't tight enough relative to a mean of 1.0 to land
+    # inside the "near-degenerate" threshold.
+    rng = _rng(58)
+    models = ["a", "b", "c", "d", "e"]
+    acc = {"a": 0.60, "b": 0.68, "c": 0.75, "d": 0.82, "e": 0.90}
+    rows = []
+    for m in models:
+        for i in range(150):
+            rows.append({
+                "model": m,
+                "item": f"q{i}",
+                "score": float(np.clip(rng.normal(acc[m], 0.08), 0, 1)),
+                "latency_ms": float(rng.normal(1.0, 0.01)),
+            })
+    evaldata = es.load_from(pd.DataFrame(rows), col_map={"model": "model", "item": "item"})
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(59),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    pareto_section = out[out.index("Pareto Front"):out.index("Executive Summary")]
+    assert "barely varies" in pareto_section
+    assert "latency_ms" in pareto_section
+
+
 def test_pareto_section_has_definition_line_and_scatterplot():
     import io
     from contextlib import redirect_stdout

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -490,7 +490,7 @@ def test_executive_summary_has_pareto_column():
         result.summary()
     out = buf.getvalue()
     exec_section = out[out.index("Executive Summary"):]
-    assert "Pareto" in exec_section.splitlines()[1]  # header row has the column
+    assert "Trade-off" in exec_section.splitlines()[1]  # header row has the column
     # claude-sonnet is dominated by gpt-4o in this fixture -- its row should say so.
     for line in exec_section.splitlines():
         if line.strip().startswith("claude-sonnet"):
@@ -508,7 +508,7 @@ def test_executive_summary_no_pareto_column_without_secondary():
         result.summary()
     out = buf.getvalue()
     exec_section = out[out.index("Executive Summary"):]
-    assert "Pareto" not in exec_section.splitlines()[1]
+    assert "Trade-off" not in exec_section.splitlines()[1]
 
 
 def test_pareto_status_phrase_merges_status_and_detail():
@@ -566,7 +566,7 @@ def test_pareto_callout_names_frontier_alternatives():
     # the bootstrap confidence threshold at this particular seed can vary,
     # so just check at least one frontier alternative is actually named.
     assert "llama-70b" in between or "gpt-4o-mini" in between
-    assert "competitive tradeoff" in between  # singular or plural
+    assert "competitive trade-off" in between  # singular or plural
 
 
 def test_pareto_callout_absent_without_secondary():

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -386,8 +386,8 @@ def test_summary_prints_pareto_section():
         result.summary()
     out = buf.getvalue()
     assert "Pareto Front" in out
-    assert "Frontier" in out
-    assert "Dominated" in out
+    assert "Best trade-off" in out
+    assert "Worse than" in out
 
 
 def test_summary_pareto_shows_probability_only_when_requested():
@@ -494,7 +494,7 @@ def test_executive_summary_has_pareto_column():
     # claude-sonnet is dominated by gpt-4o in this fixture -- its row should say so.
     for line in exec_section.splitlines():
         if line.strip().startswith("claude-sonnet"):
-            assert "Dominated" in line
+            assert "Worse than" in line
 
 
 def test_executive_summary_no_pareto_column_without_secondary():
@@ -519,11 +519,11 @@ def test_pareto_status_phrase_merges_status_and_detail():
     dominated = ParetoStatus(label="B", status="dominated", dominated_by=["A"])
     ambiguous = ParetoStatus(label="C", status="ambiguous", ambiguous_vs=["A"])
 
-    assert _pareto_status_phrase(frontier) == "Frontier"
-    assert _pareto_status_phrase(dominated) == "Dominated by A"
-    assert _pareto_status_phrase(ambiguous, verbose=True) == "Ambiguous vs A (not confirmed)"
+    assert _pareto_status_phrase(frontier) == "★ Best trade-off"
+    assert _pareto_status_phrase(dominated) == "× Worse than A on both"
+    assert _pareto_status_phrase(ambiguous, verbose=True) == "◌ Unclear vs A (not confirmed)"
     # Executive Summary's narrower column drops the "(not confirmed)" qualifier.
-    assert _pareto_status_phrase(ambiguous, verbose=False) == "Ambiguous vs A"
+    assert _pareto_status_phrase(ambiguous, verbose=False) == "◌ Unclear vs A"
 
 
 def test_pareto_table_has_single_merged_status_column():
@@ -541,7 +541,7 @@ def test_pareto_table_has_single_merged_status_column():
     out = buf.getvalue()
     pareto_section = out[out.index("Pareto Front"):out.index("Executive Summary")]
     assert "Detail" not in pareto_section
-    assert "Dominated by gpt-4o" in pareto_section
+    assert "Worse than gpt-4o on both" in pareto_section
 
 
 def test_pareto_callout_names_frontier_alternatives():
@@ -580,3 +580,55 @@ def test_pareto_callout_absent_without_secondary():
         result.summary()
     out = buf.getvalue()
     assert "leads on" not in out
+
+
+# ---------------------------------------------------------------------------
+# Scatterplot + glyph/definition line (design follow-up: visual trade-off view)
+# ---------------------------------------------------------------------------
+
+def test_pareto_status_glyphs_are_distinct():
+    from evalstats.core.summary import _pareto_status_glyph
+
+    glyphs = {_pareto_status_glyph(s) for s in ("frontier", "dominated", "ambiguous")}
+    assert len(glyphs) == 3
+
+
+def test_pareto_section_has_definition_line_and_scatterplot():
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=50)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(51),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    pareto_section = out[out.index("Pareto Front"):out.index("Executive Summary")]
+    assert "best trade-off" in pareto_section
+    # Scatterplot axis box (└...┘) and a numbered legend mapping back to names.
+    assert "└" in pareto_section and "┘" in pareto_section
+    assert "1=" in pareto_section
+    for label in _MODELS:
+        assert label in pareto_section
+
+
+def test_pareto_scatter_handles_two_entities():
+    """A minimal 2-entity case shouldn't crash the scatterplot renderer
+    (degenerate axis ranges, single frontier/dominated pair)."""
+    import io
+    from contextlib import redirect_stdout
+
+    models = _MODELS[:2]
+    evaldata = _make_evaldata(models, {k: _ACC[k] for k in models}, {k: _LAT[k] for k in models}, seed=52)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(53),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    assert "Pareto Front" in out

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -1,0 +1,410 @@
+"""Tests for evalstats.core.pareto and compare(secondary=...) propagation."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import evalstats as es
+from evalstats.core.pareto import (
+    ParetoBootstrapResult,
+    pareto_bootstrap,
+    classify_pareto_status,
+    orient_higher_is_better,
+)
+
+
+def _rng(seed: int = 0) -> np.random.Generator:
+    return np.random.default_rng(seed)
+
+
+# ---------------------------------------------------------------------------
+# orient_higher_is_better
+# ---------------------------------------------------------------------------
+
+def test_orient_max_is_noop():
+    a = np.array([1.0, 2.0, 3.0])
+    np.testing.assert_array_equal(orient_higher_is_better(a, "max"), a)
+
+
+def test_orient_min_negates():
+    a = np.array([1.0, 2.0, 3.0])
+    np.testing.assert_array_equal(orient_higher_is_better(a, "min"), -a)
+
+
+def test_orient_bad_direction_raises():
+    with pytest.raises(ValueError):
+        orient_higher_is_better(np.array([1.0]), "lower")
+
+
+# ---------------------------------------------------------------------------
+# pareto_bootstrap: core engine
+# ---------------------------------------------------------------------------
+
+def test_shape_mismatch_raises():
+    with pytest.raises(ValueError):
+        pareto_bootstrap(
+            np.zeros((2, 10)), np.zeros((2, 11)), ["a", "b"],
+            n_bootstrap=100, rng=_rng(),
+        )
+
+
+def test_label_count_mismatch_raises():
+    with pytest.raises(ValueError):
+        pareto_bootstrap(
+            np.zeros((2, 10)), np.zeros((2, 10)), ["a", "b", "c"],
+            n_bootstrap=100, rng=_rng(),
+        )
+
+
+def test_clear_dominance_detected():
+    """A dominates B on both axes with a large, unambiguous margin."""
+    rng = _rng(1)
+    M = 200
+    primary = np.stack([
+        rng.normal(0.85, 0.05, M),  # A: high
+        rng.normal(0.60, 0.05, M),  # B: low
+    ])
+    secondary = np.stack([
+        rng.normal(0.80, 0.05, M),  # A: high (already oriented so higher=better)
+        rng.normal(0.50, 0.05, M),  # B: low
+    ])
+    result = pareto_bootstrap(primary, secondary, ["A", "B"], n_bootstrap=3000, rng=_rng(2))
+    assert result.p_frontier[0] > 0.99   # A almost always on frontier
+    assert result.p_frontier[1] < 0.01   # B almost never
+    assert result.p_dominated_by[1, 0] > 0.99  # A dominates B with high confidence
+    assert result.p_dominated_by[0, 1] < 0.01
+
+    statuses = classify_pareto_status(result)
+    assert statuses["A"].status == "frontier"
+    assert statuses["B"].status == "dominated"
+    assert statuses["B"].dominated_by == ["A"]
+
+
+def test_genuine_tradeoff_both_on_frontier():
+    """A wins on primary, B wins on secondary -- neither dominates."""
+    rng = _rng(3)
+    M = 200
+    primary = np.stack([
+        rng.normal(0.85, 0.05, M),  # A: better primary
+        rng.normal(0.60, 0.05, M),  # B: worse primary
+    ])
+    secondary = np.stack([
+        rng.normal(0.30, 0.05, M),  # A: worse secondary
+        rng.normal(0.80, 0.05, M),  # B: better secondary
+    ])
+    result = pareto_bootstrap(primary, secondary, ["A", "B"], n_bootstrap=3000, rng=_rng(4))
+    statuses = classify_pareto_status(result)
+    assert statuses["A"].status == "frontier"
+    assert statuses["B"].status == "frontier"
+    assert result.p_dominated_by[0, 1] < 0.05
+    assert result.p_dominated_by[1, 0] < 0.05
+
+
+def test_flat_rate_secondary_metric_does_not_crash():
+    """A secondary metric with zero per-item variance (e.g. a flat $/token
+    rate) shouldn't cause numerical issues -- unlike a covariance-matrix
+    reconstruction approach, plain resampling degrades gracefully to a
+    constant on that axis."""
+    rng = _rng(5)
+    M = 100
+    primary = np.stack([
+        rng.normal(0.80, 0.10, M),
+        rng.normal(0.60, 0.10, M),
+    ])
+    secondary = np.stack([
+        np.full(M, 2.0),
+        np.full(M, 2.0),
+    ])
+    result = pareto_bootstrap(primary, secondary, ["A", "B"], n_bootstrap=2000, rng=_rng(6))
+    assert np.all(np.isfinite(result.p_frontier))
+    assert np.all(np.isfinite(result.p_dominated_by))
+    statuses = classify_pareto_status(result)
+    assert statuses["A"].status == "frontier"
+    assert statuses["B"].status == "dominated"
+
+
+def test_correlated_metrics_preserve_correlation():
+    """When both metrics move together across items (harder items are both
+    slower and less accurate), the joint bootstrap should reflect the
+    resulting positive dominance relationship, not treat the axes as
+    independent."""
+    rng = _rng(7)
+    M = 200
+    item_difficulty = rng.normal(0, 1, M)  # shared across both metrics
+    # A is uniformly better on both correlated axes.
+    primary = np.stack([
+        0.8 - 0.1 * item_difficulty + rng.normal(0, 0.05, M),
+        0.6 - 0.1 * item_difficulty + rng.normal(0, 0.05, M),
+    ])
+    secondary = np.stack([
+        0.7 - 0.1 * item_difficulty + rng.normal(0, 0.05, M),
+        0.5 - 0.1 * item_difficulty + rng.normal(0, 0.05, M),
+    ])
+    result = pareto_bootstrap(primary, secondary, ["A", "B"], n_bootstrap=2000, rng=_rng(8))
+    statuses = classify_pareto_status(result)
+    assert statuses["A"].status == "frontier"
+    assert statuses["B"].status == "dominated"
+
+
+# ---------------------------------------------------------------------------
+# classify_pareto_status: three-state logic (manual ParetoBootstrapResult)
+# ---------------------------------------------------------------------------
+
+def _manual_result(p_dominated_by, point_primary, point_secondary, labels=("A", "B", "C")):
+    n = len(labels)
+    return ParetoBootstrapResult(
+        labels=list(labels),
+        point_primary=np.array(point_primary),
+        point_secondary=np.array(point_secondary),
+        p_frontier=np.zeros(n),
+        p_dominated_by=np.array(p_dominated_by),
+        n_bootstrap=2000,
+    )
+
+
+def test_ambiguous_when_point_dominated_but_not_confident():
+    # B's point estimate is dominated by A on both axes, but bootstrap
+    # confidence (30%) doesn't clear the Bonferroni threshold.
+    result = _manual_result(
+        p_dominated_by=[
+            [0.0, 0.0, 0.05],
+            [0.30, 0.0, 0.02],
+            [0.0, 0.0, 0.0],
+        ],
+        point_primary=[0.75, 0.70, 0.60],
+        point_secondary=[0.50, 0.40, 0.65],
+    )
+    statuses = classify_pareto_status(result, alpha=0.05)
+    assert statuses["B"].status == "ambiguous"
+    assert statuses["B"].ambiguous_vs == ["A"]
+    assert statuses["A"].status == "frontier"
+    assert statuses["C"].status == "frontier"
+
+
+def test_dominated_when_confident():
+    result = _manual_result(
+        p_dominated_by=[
+            [0.0, 0.0, 0.05],
+            [0.99, 0.0, 0.02],  # clears the ~0.975 Bonferroni threshold at N=3
+            [0.0, 0.0, 0.0],
+        ],
+        point_primary=[0.75, 0.70, 0.60],
+        point_secondary=[0.50, 0.40, 0.65],
+    )
+    statuses = classify_pareto_status(result, alpha=0.05)
+    assert statuses["B"].status == "dominated"
+    assert statuses["B"].dominated_by == ["A"]
+
+
+def test_frontier_when_point_estimate_not_dominated():
+    # A > B > C on primary, but C > B > A on secondary -- a genuine 3-way
+    # tradeoff where no entity's point estimate dominates another's.
+    result = _manual_result(
+        p_dominated_by=np.zeros((3, 3)),
+        point_primary=[0.75, 0.60, 0.50],
+        point_secondary=[0.30, 0.80, 0.90],
+    )
+    statuses = classify_pareto_status(result, alpha=0.05)
+    for label in ["A", "B", "C"]:
+        assert statuses[label].status == "frontier"
+
+
+# ---------------------------------------------------------------------------
+# compare(secondary=...) integration
+# ---------------------------------------------------------------------------
+
+def _make_evaldata(models, acc, lat, n_items=150, seed=0, missing_cell=None):
+    rng = _rng(seed)
+    rows = []
+    for m in models:
+        for i in range(n_items):
+            rows.append({
+                "model": m,
+                "item": f"q{i}",
+                "score": float(np.clip(rng.normal(acc[m], 0.08), 0, 1)),
+                "latency_ms": float(np.clip(rng.normal(lat[m], 0.4), 0.05, None)),
+            })
+    df = pd.DataFrame(rows)
+    if missing_cell is not None:
+        model, item = missing_cell
+        df.loc[(df["model"] == model) & (df["item"] == item), "latency_ms"] = np.nan
+    return es.load_from(df, col_map={"model": "model", "item": "item"})
+
+
+_MODELS = ["gpt-4o", "claude-sonnet", "llama-70b"]
+_ACC = {"gpt-4o": 0.85, "claude-sonnet": 0.75, "llama-70b": 0.70}
+_LAT = {"gpt-4o": 2.0, "claude-sonnet": 3.0, "llama-70b": 0.6}  # llama much faster (tradeoff vs gpt-4o)
+
+
+def test_compare_secondary_end_to_end():
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=10)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(11),
+    )
+    statuses = result.pareto_status
+    assert statuses["gpt-4o"].status == "frontier"
+    assert statuses["llama-70b"].status == "frontier"       # genuine tradeoff
+    assert statuses["claude-sonnet"].status == "dominated"  # worse on both axes
+    assert statuses["claude-sonnet"].dominated_by == ["gpt-4o"]
+
+    probs = result.pareto_frontier_probability
+    assert probs["gpt-4o"] > 0.9
+    assert probs["claude-sonnet"] < 0.1
+
+
+def test_compare_no_secondary_leaves_pareto_none():
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=12)
+    result = es.compare(evaldata, factors="model", metric="score", rng=_rng(13))
+    assert result.pareto_status is None
+    assert result.pareto_frontier_probability is None
+
+
+def test_compare_secondary_bad_direction_raises():
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=14)
+    with pytest.raises(ValueError):
+        es.compare(
+            evaldata, factors="model", metric="score",
+            secondary={"latency_ms": "lower"}, rng=_rng(15),
+        )
+
+
+def test_compare_secondary_n_way_not_implemented():
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=16)
+    with pytest.raises(NotImplementedError):
+        es.compare(
+            evaldata, factors="model", metric="score",
+            secondary={"latency_ms": "min", "score": "max"}, rng=_rng(17),
+        )
+
+
+def test_compare_secondary_non_dict_warns_and_ignores():
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=18)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = es.compare(
+            evaldata, factors="model", metric="score",
+            secondary="latency_ms", rng=_rng(19),
+        )
+        assert any("secondary=" in str(x.message) for x in w)
+    assert result.pareto_status is None
+
+
+def test_compare_secondary_missing_column_raises():
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=20)
+    with pytest.raises(es.EvalLoadError):
+        es.compare(
+            evaldata, factors="model", metric="score",
+            secondary={"nonexistent_col": "min"}, rng=_rng(21),
+        )
+
+
+def test_compare_secondary_incomplete_design_raises():
+    evaldata = _make_evaldata(
+        _MODELS, _ACC, _LAT, seed=22, missing_cell=("llama-70b", "q0"),
+    )
+    with pytest.raises(ValueError, match="missing"):
+        es.compare(
+            evaldata, factors="model", metric="score",
+            secondary={"latency_ms": "min"}, rng=_rng(23),
+        )
+
+
+def test_compare_secondary_warns_for_multi_model():
+    rng = _rng(24)
+    rows = []
+    for m in ["gpt-4o", "claude-sonnet"]:
+        for p in ["p1", "p2"]:
+            for i in range(60):
+                rows.append({
+                    "model": m, "prompt": p, "item": f"q{i}",
+                    "score": float(np.clip(rng.normal(0.7, 0.1), 0, 1)),
+                    "latency_ms": float(rng.normal(2.0, 0.3)),
+                })
+    df = pd.DataFrame(rows)
+    evaldata = es.load_from(df, col_map={"model": "model", "prompt": "prompt", "item": "item"})
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = es.compare(
+            evaldata, factors="model", metric="score",
+            secondary={"latency_ms": "min"}, rng=_rng(25),
+        )
+        assert any("multi-model" in str(x.message) for x in w)
+    assert result.pareto_status is None
+
+
+def test_to_dict_includes_pareto():
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=26)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(27), show_rank_probabilities=True,
+    )
+    d = result.to_dict()
+    assert d["pareto"]["secondary_metric"] == "latency_ms"
+    assert d["pareto"]["direction"] == "min"
+    assert d["pareto"]["entities"]["claude-sonnet"]["status"] == "dominated"
+    assert "p_pareto_optimal" in d["pareto"]["entities"]["gpt-4o"]
+
+
+def test_to_dict_omits_p_pareto_optimal_by_default():
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=28)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(29),
+    )
+    d = result.to_dict()
+    assert "p_pareto_optimal" not in d["pareto"]["entities"]["gpt-4o"]
+
+
+def test_to_frame_includes_pareto():
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=30)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(31),
+    )
+    frames = result.to_frame()
+    assert "pareto" in frames
+    assert set(frames["pareto"]["entity"]) == set(_MODELS)
+
+
+def test_summary_prints_pareto_section():
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=32)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(33),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    assert "Pareto Front" in out
+    assert "Frontier" in out
+    assert "Dominated" in out
+
+
+def test_summary_pareto_shows_probability_only_when_requested():
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=34)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(35),
+    )
+
+    buf1 = io.StringIO()
+    with redirect_stdout(buf1):
+        result.summary()
+    assert "P(Pareto-optimal)" not in buf1.getvalue()
+
+    buf2 = io.StringIO()
+    with redirect_stdout(buf2):
+        result.summary(show_rank_probabilities=True)
+    assert "P(Pareto-optimal)" in buf2.getvalue()

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -509,3 +509,74 @@ def test_executive_summary_no_pareto_column_without_secondary():
     out = buf.getvalue()
     exec_section = out[out.index("Executive Summary"):]
     assert "Pareto" not in exec_section.splitlines()[1]
+
+
+def test_pareto_status_phrase_merges_status_and_detail():
+    from evalstats.core.summary import _pareto_status_phrase
+    from evalstats.core.pareto import ParetoStatus
+
+    frontier = ParetoStatus(label="A", status="frontier")
+    dominated = ParetoStatus(label="B", status="dominated", dominated_by=["A"])
+    ambiguous = ParetoStatus(label="C", status="ambiguous", ambiguous_vs=["A"])
+
+    assert _pareto_status_phrase(frontier) == "Frontier"
+    assert _pareto_status_phrase(dominated) == "Dominated by A"
+    assert _pareto_status_phrase(ambiguous, verbose=True) == "Ambiguous vs A (not confirmed)"
+    # Executive Summary's narrower column drops the "(not confirmed)" qualifier.
+    assert _pareto_status_phrase(ambiguous, verbose=False) == "Ambiguous vs A"
+
+
+def test_pareto_table_has_single_merged_status_column():
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=44)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(45),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    pareto_section = out[out.index("Pareto Front"):out.index("Executive Summary")]
+    assert "Detail" not in pareto_section
+    assert "Dominated by gpt-4o" in pareto_section
+
+
+def test_pareto_callout_names_frontier_alternatives():
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=46)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(47),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    exec_idx = out.index("Executive Summary")
+    next_idx = out.index("What to do next")
+    between = out[exec_idx:next_idx]
+    assert "leads on score" in between
+    # llama-70b and gpt-4o-mini are both genuine tradeoffs against gpt-4o in
+    # this fixture (see test_compare_secondary_end_to_end); which ones clear
+    # the bootstrap confidence threshold at this particular seed can vary,
+    # so just check at least one frontier alternative is actually named.
+    assert "llama-70b" in between or "gpt-4o-mini" in between
+    assert "competitive tradeoff" in between  # singular or plural
+
+
+def test_pareto_callout_absent_without_secondary():
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=48)
+    result = es.compare(evaldata, factors="model", metric="score", rng=_rng(49))
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    assert "leads on" not in out

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -15,6 +15,7 @@ from evalstats.core.pareto import (
     classify_pareto_status,
     orient_higher_is_better,
 )
+from evalstats.core.summary import _pareto_sorted_labels
 
 
 def _rng(seed: int = 0) -> np.random.Generator:
@@ -408,3 +409,103 @@ def test_summary_pareto_shows_probability_only_when_requested():
     with redirect_stdout(buf2):
         result.summary(show_rank_probabilities=True)
     assert "P(Pareto-optimal)" in buf2.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Section ordering, sorting, and richer statistics (design follow-up)
+# ---------------------------------------------------------------------------
+
+def test_pareto_sorted_labels_groups_by_status_then_primary_mean():
+    labels = ["A", "B", "C", "D"]
+    result = ParetoBootstrapResult(
+        labels=labels,
+        point_primary=np.array([0.60, 0.90, 0.70, 0.50]),  # B > C > A > D
+        point_secondary=np.zeros(4),
+        p_frontier=np.zeros(4),
+        p_dominated_by=np.zeros((4, 4)),
+        n_bootstrap=1000,
+    )
+    statuses = {
+        "A": type("S", (), {"status": "frontier"})(),
+        "B": type("S", (), {"status": "dominated"})(),
+        "C": type("S", (), {"status": "frontier"})(),
+        "D": type("S", (), {"status": "ambiguous"})(),
+    }
+    pareto = {"result": result, "statuses": statuses}
+    # frontier group (C, A by primary desc), then ambiguous (D), then dominated (B).
+    assert _pareto_sorted_labels(pareto) == ["C", "A", "D", "B"]
+
+
+def test_pareto_front_precedes_executive_summary():
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=36)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(37),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    pareto_idx = out.index("Pareto Front")
+    exec_idx = out.index("Executive Summary")
+    assert pareto_idx < exec_idx
+
+
+def test_pareto_table_shows_secondary_metric_statistics():
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=38)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(39),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    assert "latency_ms" in out
+    assert "95% CI" in out
+    # Secondary metric's calibrated CI is actually computed and stored.
+    sec_rob = result._pareto["secondary_robustness"]
+    assert sec_rob.ci_low is not None and sec_rob.ci_high is not None
+    for lo, hi in zip(sec_rob.ci_low, sec_rob.ci_high):
+        assert lo <= hi
+
+
+def test_executive_summary_has_pareto_column():
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=40)
+    result = es.compare(
+        evaldata, factors="model", metric="score",
+        secondary={"latency_ms": "min"}, rng=_rng(41),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    exec_section = out[out.index("Executive Summary"):]
+    assert "Pareto" in exec_section.splitlines()[1]  # header row has the column
+    # claude-sonnet is dominated by gpt-4o in this fixture -- its row should say so.
+    for line in exec_section.splitlines():
+        if line.strip().startswith("claude-sonnet"):
+            assert "Dominated" in line
+
+
+def test_executive_summary_no_pareto_column_without_secondary():
+    import io
+    from contextlib import redirect_stdout
+
+    evaldata = _make_evaldata(_MODELS, _ACC, _LAT, seed=42)
+    result = es.compare(evaldata, factors="model", metric="score", rng=_rng(43))
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result.summary()
+    out = buf.getvalue()
+    exec_section = out[out.index("Executive Summary"):]
+    assert "Pareto" not in exec_section.splitlines()[1]


### PR DESCRIPTION
## Summary

Adds `compare(secondary={"latency_s": "min"})` — an uncertainty-aware Pareto-front
analysis for a primary metric plus one secondary metric (e.g. accuracy vs. latency,
quality vs. cost). Unlike a naive Pareto front on point estimates, dominance calls
are backed by a joint bootstrap (shared per-item resample across both metrics, so
correlation between them is preserved) and reduced to a three-state, FWER-aware
verdict per entity: **frontier** (no confident dominator), **dominated** (confidently
beaten on both axes by a specific entity), or **ambiguous** (point estimate looks
dominated, but not enough evidence to confirm it).

## What's new in the terminal output

- A **Pareto Front** section (before the Executive Summary) showing each entity's
  calibrated mean + 95% CI on both metrics, an ASCII scatterplot with a numbered
  legend and status glyphs (★ frontier / ◌ ambiguous / × dominated), and an optional
  `P(Pareto-optimal)` confidence-bar breakdown.
- The **Executive Summary** gains two paired columns — `On {metric}` (primary-metric
  verdict, unchanged logic) and `Trade-off vs {secondary}` (the Pareto verdict) —
  plus a one-line callout bridging the primary-metric leader to any competitive
  frontier alternatives.
- Plain-language status wording throughout (`Best trade-off` / `Worse than X on both`
  / `Unclear vs X`) instead of raw jargon, with dominator lists capped so a
  heavily-dominated entity doesn't blow out the table width.

## API

- `ComparisonResult.pareto_status` / `.pareto_frontier_probability` for programmatic access.
- `to_dict()`/`to_frame()` gain a `"pareto"` key/frame.
- Currently bivariate only (one secondary metric); raises `NotImplementedError` for
  N-way. Not yet supported for multi-model/factorial comparisons or seeded benchmarks
  (warns/raises accordingly rather than silently mis-computing).

## Testing

`tests/test_pareto.py` (42 tests): bootstrap engine unit tests (clear dominance,
genuine tradeoff, flat/correlated metrics), full `compare(secondary=...)` integration,
printed-summary structure (ordering, sorting, scatterplot, column headers, callout),
and edge cases battle-tested by hand (12+ entities, one dominant winner, 2-entity
minimum, `direction="max"`, near-degenerate axes, long entity names, negative-valued
metrics).

Runnable demo: `examples/compare_pareto_secondary_metric.py`.