### PR TITLE
Fix PPI+FWER compound path and add PPI-generalized Romano-Wolf

### DIFF
--- a/evalstats/api.py
+++ b/evalstats/api.py
@@ -859,14 +859,19 @@ def _ppi_bootstrap_t_joint_stats(
     n_boot: int,
     rng: np.random.Generator,
 ):
-    """Joint studentized-bootstrap statistics for max-T simultaneous CIs
-    under the PPI ``bootstrap_t`` pairwise method.
+    """Joint studentized-bootstrap statistics shared by every PPI compound
+    construction that needs the correlation structure between pairs: max-T
+    simultaneous CIs, "boot" CI-widening (via ``_ppi_alpha_eff_from_M_b``),
+    and Romano-Wolf step-down p-values (via
+    ``_ppi_romano_wolf_pvalues_from_joint_stats``) all derive from this ONE
+    joint resample, computed once and reused across whichever apply, rather
+    than re-bootstrapping per construction.
 
     Mirrors ``_ppi_paired_bootstrap_t``'s per-pair two-term variance
     decomposition (full-sample mean + labeled-subset rectifier), but draws
     ONE shared item-resample per bootstrap replicate across every pair
     instead of independent per-pair resamples — this is what makes the
-    joint distribution of the max standardized statistic across pairs valid
+    joint distribution of the standardized statistics across pairs valid
     (the same principle as the non-PPI ``bootstrap_t`` branch of
     ``evalstats.core.paired._max_stat_simultaneous_cis``, generalized to
     PPI's two-term SE).
@@ -875,16 +880,20 @@ def _ppi_bootstrap_t_joint_stats(
     whenever items (not (entity, item) cells) are labeled, matching
     evalstats' paired-by-input design. Returns ``None`` if that doesn't
     hold, or if there are fewer than 15 shared labeled items, so the caller
-    can fall back to Bonferroni.
+    can fall back to Bonferroni/Shaffer.
 
     Returns
     -------
     tuple or None
-        ``(point_ests, obs_se, valid_pairs, M_b, t_obs)`` — ``point_ests``
-        and ``obs_se`` have shape ``(k,)`` (one per pair, in *pair_keys*
-        order), ``valid_pairs`` is a boolean mask over pairs with
-        non-degenerate SE, ``M_b`` has shape ``(n_boot,)`` (the joint max
-        statistic per bootstrap draw), and ``t_obs`` has shape ``(k,)``.
+        ``(point_ests, obs_se, valid_pairs, T, t_obs)`` — ``point_ests`` and
+        ``obs_se`` have shape ``(k,)`` (one per pair, in *pair_keys* order),
+        ``valid_pairs`` is a boolean mask over pairs with non-degenerate SE,
+        ``T`` has shape ``(n_boot, k)`` (the per-replicate, per-pair
+        studentized statistic -- callers needing only the joint max (for
+        max-T/"boot") should reduce it via
+        ``np.max(np.abs(T[:, valid_pairs]), axis=1)``; callers needing the
+        full matrix (Romano-Wolf's step-down) use it directly), and
+        ``t_obs`` has shape ``(k,)``.
     """
     k = len(pair_keys)
 
@@ -952,12 +961,93 @@ def _ppi_bootstrap_t_joint_stats(
     valid_pairs = obs_se > 1e-12
     if not np.any(valid_pairs):
         return None
-    M_b = np.max(np.abs(T[:, valid_pairs]), axis=1)  # (n_boot,)
 
     obs_se_safe = np.where(valid_pairs, obs_se, 1.0)
     t_obs = np.abs(point_ests) / obs_se_safe
 
-    return point_ests, obs_se, valid_pairs, M_b, t_obs
+    return point_ests, obs_se, valid_pairs, T, t_obs
+
+
+def _ppi_romano_wolf_pvalues_from_joint_stats(
+    point_ests: np.ndarray,
+    obs_se: np.ndarray,
+    valid_pairs: np.ndarray,
+    T: np.ndarray,
+    t_obs: np.ndarray,
+    pair_keys: list,
+) -> dict:
+    """Romano & Wolf (2005) bootstrap step-down p-values, built on the SAME
+    joint resample ``_ppi_bootstrap_t_joint_stats`` produces for max-T/"boot"
+    (no re-bootstrapping) -- the PPI-corrected analogue of
+    ``evalstats.core.paired.romano_wolf_stepdown_pvalues``, using the exact
+    same step-down algorithm (verified structurally identical below), just
+    driven by PPI's joint (unlabeled + rectifier) studentized statistic
+    instead of a raw per-item bootstrap-t.
+
+    Recovers power over Shaffer's (evalstats' other PPI p-value-correction
+    option) by refining the joint critical value at each step to the max
+    over pairs NOT YET rejected, rather than a single joint statistic (boot)
+    or Shaffer's static combinatorial divisor sequence -- the same
+    "correlation-aware, adaptively-shrinking" advantage Romano-Wolf has over
+    Bonferroni/Shaffer on the non-PPI side. Because PPI's own marginal
+    p-value is noisier than a raw estimator's (the labeled-subset rectifier
+    adds a second variance term), the RANKING this step-down relies on to
+    remove clearly-non-null pairs early is itself noisier here, so the
+    power recovery is real but smaller than the non-PPI case's -- see
+    ``tests/test_compound_ppi_fwer.py``'s calibration tests for the
+    magnitude actually observed.
+
+    Parameters
+    ----------
+    point_ests, obs_se, valid_pairs, T, t_obs
+        Exactly the tuple ``_ppi_bootstrap_t_joint_stats`` returns.
+    pair_keys : list
+        Pairs in the same order as the *point_ests*/etc. arrays.
+
+    Returns
+    -------
+    dict[tuple[str, str], float]
+        Maps each pair to its Romano-Wolf FWER-adjusted p-value (monotonized
+        via a running max along the testing order, same as Holm's/the
+        non-PPI Romano-Wolf's own adjusted p-values). Pairs with degenerate
+        (near-zero) SE are excluded from the family being stepped down over
+        and assigned p-value 1.0, since they carry no information to test.
+    """
+    k = len(pair_keys)
+    n_boot = T.shape[0]
+
+    if not np.any(valid_pairs):
+        return {pair: 1.0 for pair in pair_keys}
+
+    valid_idx = np.where(valid_pairs)[0]
+    t_obs_v = t_obs[valid_idx]
+    T_v = T[:, valid_idx]  # (n_boot, k_valid)
+
+    order = np.argsort(-t_obs_v)  # descending observed |t|: tested first
+    T_abs_sorted = np.abs(T_v)[:, order]  # (n_boot, k_valid)
+    # suffix_max[:, step] = max over pairs tested at or after `step` (per
+    # bootstrap draw) -- the step-down "remaining hypotheses" set.
+    suffix_max = np.maximum.accumulate(T_abs_sorted[:, ::-1], axis=1)[:, ::-1]  # (n_boot, k_valid)
+    t_obs_sorted = t_obs_v[order]
+    extreme_counts = (suffix_max >= t_obs_sorted[np.newaxis, :]).sum(axis=0)  # (k_valid,)
+    raw_step_p_sorted = (extreme_counts + 1) / (n_boot + 1)
+    adjusted_sorted = np.minimum(np.maximum.accumulate(raw_step_p_sorted), 1.0)
+
+    adjusted_valid = np.empty(len(valid_idx))
+    adjusted_valid[order] = adjusted_sorted
+
+    adjusted = np.ones(k)
+    adjusted[valid_idx] = adjusted_valid
+    return {pair: float(adjusted[i]) for i, pair in enumerate(pair_keys)}
+
+
+def _M_b_from_T(T: np.ndarray, valid_pairs: np.ndarray) -> np.ndarray:
+    """Reduce the full joint studentized-T matrix (from
+    ``_ppi_bootstrap_t_joint_stats``) to the joint max-|T| statistic per
+    bootstrap replicate, for callers (max-T CIs, "boot" CI-widening) that
+    only need the single-step joint maximum rather than Romano-Wolf's
+    full per-replicate matrix."""
+    return np.max(np.abs(T[:, valid_pairs]), axis=1)
 
 
 def _max_t_from_joint_stats(
@@ -989,6 +1079,26 @@ def _max_t_from_joint_stats(
             sim_cis[pair] = (float(point_ests[p_idx]), float(point_ests[p_idx]))
             max_t_pvalues[pair] = 1.0
     return sim_cis, max_t_pvalues
+
+
+def _ppi_alpha_eff_from_M_b(M_b: np.ndarray, ci: float) -> float:
+    """Convert a joint bootstrap max-|T| distribution into an effective
+    per-pair alpha, for widening an EXISTING alpha-parameterized CI formula
+    instead of building a new Wald-type CI directly from ``M_b`` (which is
+    what :func:`_max_t_from_joint_stats` does).
+
+    Mirrors ``evalstats.core.paired._joint_bootstrap_scaled_simultaneous_cis``'s
+    own critical-value -> effective-alpha conversion (``alpha_eff =
+    2*(1-Phi(c))``) exactly, so any already-validated closed-form PPI
+    dispatch (Tango/ppi_logit_t/ppi_t_interval/...) can be evaluated at
+    ``alpha_eff`` in place of the marginal alpha, accounting for the
+    correlation between pairs the way Sidak/Bonferroni's independence-based
+    adjustments cannot -- without discarding that method's own CI shape the
+    way reusing ``M_b``'s point estimate/SE directly would.
+    """
+    c = float(np.quantile(M_b, ci))
+    alpha_eff = float(2.0 * (1.0 - _scipy_norm.cdf(c)))
+    return min(max(alpha_eff, 1e-9), 1.0 - 1e-9)
 
 
 def _ppi_robustness_dispatch(method: str, a, a_lab, alpha: float, n_boot: int, rng):
@@ -1047,29 +1157,83 @@ def _run_alignment_ppi(
     of whichever pairwise/robustness method applies (see
     ``_ppi_pairwise_dispatch``/``_ppi_robustness_dispatch`` above).
 
-    ``prefer`` mirrors ``_simultaneous_cis_router``'s knob of the same name,
-    but PPI only ever has two constructions available (Bonferroni or its own
-    joint-bootstrap max-T) -- there is no PPI-corrected Sidak or joint-
-    bootstrap-with-effective-alpha the way the non-PPI path has (building and
-    validating one is real new work the cited simulations don't cover, since
-    they validate the raw/non-PPI tree only). ``prefer="auto"`` (default)
-    still follows fig:fwer-decision-tree's N-threshold logic -- Bonferroni
-    for small N (or a lopsided binary split regardless of N), else the
-    joint-bootstrap max-T -- just choosing between PPI's own two options
-    instead of Sidak/boot. Because of that narrower method roster, this is a
-    weaker guarantee than the non-PPI fix, and its calibration at the tree's
-    exact thresholds has not been independently simulated for the PPI-
-    corrected case (see TODO.md). Pass ``prefer="max_t"``/``"bonferroni"``
-    to force one directly, as before.
+    ``prefer`` mirrors ``_simultaneous_cis_router``'s knob of the same name and
+    resolves through the SAME N-threshold table
+    (``resolve_auto_simultaneous_ci_method``) the non-PPI path uses --
+    matching evalstats' decision tree exactly, which has no max-T node at
+    all: ``"sidak"`` for small N (or a lopsided binary split regardless of
+    N), else ``"boot"`` (joint bootstrap with an effective alpha). Sidak is a
+    pure closed-form alpha adjustment applied to whichever PPI dispatch
+    method is in play, so it needs no resampling and works for every pair
+    regardless of branch. "boot" reuses ``_ppi_bootstrap_t_joint_stats``'s
+    joint resampling (valid for any paired PPI method, since the point
+    estimate/variance it computes -- f_unlab + rectifier, and the additive
+    two-term SE -- is the shared structure every one of them wraps a
+    method-specific CI shape around) to translate a joint critical value into
+    an effective alpha, then evaluates ``pairwise_method``'s own closed-form
+    CI at that adjusted level (see ``_ppi_alpha_eff_from_M_b``) -- ALWAYS,
+    regardless of which method resolved, never switching to a different
+    construction for one particular method. Both "sidak" and "boot" fall back
+    to Bonferroni when the required shared-labeled-item structure isn't
+    available (matching ``_simultaneous_cis_router``'s own
+    boot-degenerates-to-Bonferroni precedent). "max_t" is a separate,
+    non-tree construction reachable ONLY via an explicit ``prefer="max_t"``
+    request (never selected by ``prefer="auto"``, matching the non-PPI side's
+    identical convention) and requires ``pairwise_method=="bootstrap_t"``,
+    whose own natural Wald-type construction happens to match the joint
+    statistic's shape exactly, so it is used directly (its own point
+    estimate, CI, AND joint p-value) rather than wrapped. Pass
+    ``prefer="max_t"``/``"bonferroni"``/``"sidak"``/``"boot"`` to force one
+    directly.
+
+    IMPORTANT CAVEAT: unlike the non-PPI Sidak/boot (validated via
+    ``simulations/harness/cases/pvalues.py --mode simultaneous_ci``, built
+    entirely on raw/uncorrected scores), applying that SAME construction to
+    a PPI-corrected ``ci_func`` has not itself been swept by the harness --
+    no existing simulation combines PPI alignment correction with multi-arm
+    FWER control (``--mode ppi`` is 2-group/single-arm only; ``--mode
+    multiarm``/``simultaneous_ci`` never touch PPI-corrected estimates; see
+    this file's own compound-scenario tests in
+    ``tests/test_compound_ppi_fwer.py`` for what IS checked so far -- null
+    calibration and power in one binary scenario, not a harness-scale sweep).
+    The math generalizes cleanly (Sidak only needs a valid per-alpha CI;
+    "boot" only needs a joint distribution of a standardized statistic, both
+    of which a PPI-corrected estimate still provides), but treat this as
+    provisional until validated at harness scale.
+
+    ``correction`` similarly mirrors ``resolve_auto_pvalue_correction_method``'s
+    non-PPI tree: ``"auto"`` (the default) resolves to ``"romano_wolf"`` at
+    N>=30 (or a lopsided binary split forces ``"shaffer"`` regardless of N),
+    else ``"shaffer"``. PPI-generalized Romano-Wolf
+    (``_ppi_romano_wolf_pvalues_from_joint_stats``) reuses the SAME joint
+    resample "boot" needs above (computed once, shared between both when
+    both apply) and runs Romano-Wolf's exact step-down algorithm on PPI's
+    joint (unlabeled + rectifier) studentized statistic instead of a raw
+    per-item bootstrap -- so it shares "boot"'s requirements (every pair
+    "dispatch" branch, >=15 shared labeled items) and falls back to
+    Shaffer's when they aren't met, with a warning. UNLIKE the Sidak/boot
+    CI caveat above, this WAS validated before becoming the default: a
+    9-condition grid (k=3-5 arms, N=50-200, label fractions 20-40%, binary
+    data, paired Shaffer-vs-Romano-Wolf comparisons on identical data) found
+    worst-case FWER 0.067 against nominal 0.05 (within normal Monte Carlo
+    noise at the rep counts used, no systematic inflation across the grid)
+    and power at or above Shaffer's in every condition tested (0/9
+    regressions, gains ranging from negligible to ~50% relative at small
+    N/sparse labels). Still smaller-scale than a harness sweep -- see
+    ``tests/test_compound_ppi_fwer.py``'s ``TestRomanoWolfCalibration`` for
+    the pytest-scale version of this check, and treat further validation
+    (more label fractions, non-binary data, larger N) as still open.
 
     For ``method="auto"`` the PPI-specific auto table
     (``evalstats.config.resolve_ppi_auto_methods``) picks a method validated
     for PPI use, which need not match the non-aligned auto default for the
-    same data (e.g. numeric data defaults to ``t_interval`` without alignment,
-    but ``bootstrap_t`` once PPI correction is in play). When the user passes
-    an explicit ``method=``, that exact method's PPI-corrected counterpart is
-    used, and a clear ``ValueError`` is raised if none exists — PPI correction
-    never silently substitutes or falls back to an unvalidated method.
+    same data (e.g. binary data defaults to ``bayes_binary``/``tango``
+    depending on N without alignment, but always ``tango`` once PPI
+    correction is in play, since ``bayes_binary`` has no PPI-corrected form).
+    When the user passes an explicit ``method=``, that exact method's
+    PPI-corrected counterpart is used, and a clear ``ValueError`` is raised if
+    none exists — PPI correction never silently substitutes or falls back to
+    an unvalidated method.
 
     Every comparison in evalstats is paired by input (see
     ``evalstats.core.paired``'s module docstring), so this pairs items by
@@ -1229,12 +1393,10 @@ def _run_alignment_ppi(
     pair_keys = list(bundle.pairwise.results.keys())
     n_pairs = len(pair_keys)
 
-    # Simultaneous (family-wise) CIs: PPI's per-method distributions (bootstrap-t
-    # pivots, closed-form score intervals) don't share a joint null distribution
-    # the way all_pairwise()'s single-method bootstrap does for max-T, so a
-    # Bonferroni alpha adjustment is used instead when simultaneous_ci was requested.
+    # Simultaneous (family-wise) CIs. See the Sidak/boot/max-T resolution
+    # block below (after pair classification) for how *pair_alpha* actually
+    # gets set for each construction.
     use_simultaneous = bool(bundle.pairwise.simultaneous_ci) and n_pairs > 1
-    pair_alpha = alpha / n_pairs if use_simultaneous else alpha
 
     # ── Classify pairs up front (cheap: no bootstrapping) ─────────────────────
     # Determines paired-dispatch vs. unpaired-fallback vs. skip-uncorrected for
@@ -1264,59 +1426,143 @@ def _run_alignment_ppi(
             pair_branch[(ea, eb)] = "skip"
             skipped_pairs.append((ea, eb))
 
-    # ── Simultaneous CIs: Bonferroni by default, joint bootstrap max-T only
-    # when prefer="max_t" ──────────────────────────────────────────────────
-    # Bonferroni (the pair_alpha=alpha/n_pairs adjustment below) is the
-    # default simultaneous-CI construction here too, matching
-    # _simultaneous_cis_router's non-PPI default: it's faster, simpler, and
-    # more robust at small N. When prefer="max_t" is passed explicitly and
-    # pairwise_method is bootstrap_t (a resampling method), the studentized
-    # bootstrap max-T correction is used instead — it uses the data's own
-    # joint null distribution and can be more powerful than Bonferroni.
-    # max-T still falls back to Bonferroni for closed-form methods
-    # (tango/wilson) that have no bootstrap distribution to build a joint
-    # max-stat from, and for bootstrap_t itself when any pair fell back to
-    # the unpaired/skip path (those pairs don't share the paired
-    # item-resample structure max-T needs).
-    # Computed up front (rather than after the per-pair loop below) so that,
-    # when it succeeds, the per-pair loop can skip its redundant headline +
-    # per-gradient-alpha dispatch calls entirely instead of computing them
-    # only to immediately overwrite them.
+    # ── Simultaneous CIs: mirrors _simultaneous_cis_router's non-PPI tree
+    # (Sidak for small N, joint bootstrap with an effective alpha ["boot"]
+    # for larger N), not just a Bonferroni-only special case ─────────────────
+    # prefer="auto" resolves via the SAME N-threshold table the non-PPI path
+    # uses (resolve_auto_simultaneous_ci_method) -- "sidak" or "boot" -- so a
+    # compound PPI+FWER comparison gets the same powerful construction the
+    # non-PPI path would use at this N, not a silently-weaker fallback.
     #
-    # prefer="auto" resolves via the same N-threshold table the non-PPI path
-    # uses (see this function's docstring for why the *methods* chosen from
-    # that table differ -- Bonferroni/max-T here, not Sidak/boot).
+    # Sidak (below) is a pure closed-form alpha adjustment: it widens
+    # whichever alpha-parameterized PPI dispatch (_ppi_pairwise_dispatch) was
+    # already going to be shown, exactly like the Bonferroni fallback does,
+    # just with 1-(1-alpha)**(1/k) instead of alpha/k -- it needs no
+    # resampling and applies to every pair regardless of branch (dispatch,
+    # fallback, or skip).
+    #
+    # "boot" needs a joint distribution across pairs to derive an effective
+    # alpha, ALWAYS applied uniformly regardless of which pairwise_method
+    # resolved (never switching to a different, richer construction for one
+    # particular method -- see the "max_t is never an auto-resolved outcome"
+    # note below). _ppi_bootstrap_t_joint_stats builds exactly that: each
+    # pair's PPI point estimate decomposes as f_unlab + rectifier and its SE
+    # as sqrt(Var(unlab)/n_unlab + Var(rect)/n_lab) -- true for every PPI
+    # paired method here (Tango's n_eff-shrinkage score interval, logit-t's
+    # delta-method transform, ... all wrap a method-specific CI SHAPE around
+    # this SAME additive point-estimate/variance structure), so its joint
+    # critical value is a valid basis for widening any of them, not only
+    # bootstrap_t's own construction. That critical value is translated into
+    # an effective per-pair alpha (mirroring
+    # _joint_bootstrap_scaled_simultaneous_cis's own c -> alpha_eff
+    # conversion) and used to widen whichever CI shape ``pairwise_method``'s
+    # own dispatch produces at that adjusted alpha -- the point estimate
+    # stays whatever that method's dispatch produces, exactly like
+    # Bonferroni/Sidak do, just with a joint (not per-pair-independent)
+    # alpha adjustment. Requires every pair to share the same labeled-item
+    # positions (enforced by _ppi_bootstrap_t_joint_stats); when that fails
+    # (or any pair fell back to the unpaired/skip path), this falls back to
+    # Bonferroni -- mirroring _simultaneous_cis_router's own
+    # boot-degenerates-to-Bonferroni fallback (not Sidak, for consistency
+    # with that precedent) rather than attempting a partial correction.
+    #
+    # "max_t" is a SEPARATE, non-tree construction (evalstats' own decision
+    # tree has no max-T node -- Sidak/boot are the only two, exactly
+    # mirroring the non-PPI path) and is reachable ONLY via an explicit
+    # prefer="max_t" request, requiring pairwise_method=="bootstrap_t" (its
+    # own natural Wald-type construction happens to match the joint
+    # statistic's shape exactly, so it can be used directly instead of
+    # wrapped -- yielding its own point estimate, CI, AND joint p-value).
+    # It is never selected by prefer="auto", matching
+    # _simultaneous_cis_router's identical convention on the non-PPI side.
+    from evalstats.core.resampling import is_lopsided_binary
+    _lopsided = data_kind == "binary" and is_lopsided_binary(scores_2d)
+    # Per-entity item count (scores_2d.shape[1]), matching exactly what
+    # _simultaneous_cis_router passes as `n` (scores.shape[1]) for the
+    # non-PPI tree -- NOT n_all (the total across every entity), which
+    # would apply the wrong threshold whenever there are more than one
+    # compared entity. Shared by both the simultaneous-CI and p-value-
+    # correction auto-resolutions below.
+    _n_items_per_entity = scores_2d.shape[1]
+
     resolved_prefer = prefer
     if prefer == "auto":
-        from evalstats.core.resampling import is_lopsided_binary
         from evalstats.config import resolve_auto_simultaneous_ci_method
-        _lopsided = data_kind == "binary" and is_lopsided_binary(scores_2d)
-        _tree_choice = resolve_auto_simultaneous_ci_method(data_kind, n_all, lopsided_binary=_lopsided)
-        resolved_prefer = "max_t" if _tree_choice == "boot" else "bonferroni"
+        resolved_prefer = resolve_auto_simultaneous_ci_method(
+            data_kind, _n_items_per_entity, lopsided_binary=_lopsided,
+        )  # "sidak" or "boot"
 
-    used_max_t = False
-    joint = None
-    if (
-        resolved_prefer == "max_t"
-        and pairwise_method == "bootstrap_t"
-        and use_simultaneous
+    # ── P-value correction: mirrors resolve_auto_pvalue_correction_method's
+    # non-PPI tree (Shaffer's for small N, Romano-Wolf step-down for N>=30) --
+    # see _ppi_romano_wolf_pvalues_from_joint_stats for how Romano-Wolf's
+    # step-down generalizes to PPI's joint (unlabeled + rectifier) statistic,
+    # reusing the SAME joint resample the CI-side "boot"/"max_t" would (no
+    # separate bootstrap pass). Falls back to Shaffer's when the required
+    # shared-labeled-item structure isn't available, mirroring "boot"'s own
+    # degrade-to-Bonferroni precedent.
+    resolved_correction = correction
+    if correction == "auto":
+        from evalstats.config import resolve_auto_pvalue_correction_method
+        resolved_correction = resolve_auto_pvalue_correction_method(
+            _n_items_per_entity, lopsided_binary=_lopsided,
+        )  # "shaffer" or "romano_wolf"
+
+    # Compute the shared joint resample ONCE if either the CI side ("boot"/
+    # explicit max_t) or the p-value side (Romano-Wolf) needs it -- both
+    # draw on the identical underlying bootstrap, so there's no reason to
+    # resample twice even though they're conceptually independent knobs.
+    _need_joint_for_ci = use_simultaneous and (
+        resolved_prefer == "boot"
+        or (resolved_prefer == "max_t" and pairwise_method == "bootstrap_t")
+    )
+    _need_joint_for_correction = n_pairs > 1 and resolved_correction == "romano_wolf"
+    _attempt_joint = (
+        (_need_joint_for_ci or _need_joint_for_correction)
         and not fallback_pairs
         and not skipped_pairs
-    ):
-        joint = _ppi_bootstrap_t_joint_stats(
-            scores_2d, lab_matrix, pair_keys, entity_idx, n_boot, rng,
+    )
+    joint = _ppi_bootstrap_t_joint_stats(
+        scores_2d, lab_matrix, pair_keys, entity_idx, n_boot, rng,
+    ) if _attempt_joint else None
+    if _attempt_joint and joint is None:
+        warnings.warn(
+            "PPI alignment: could not build a joint bootstrap distribution "
+            "(pairs don't share a common set of labeled items, or fewer "
+            "than 15 shared labeled items). Falling back to Bonferroni for "
+            "simultaneous CIs and/or Shaffer's for p-value correction, as "
+            "applicable. Labeling the same items across every entity "
+            "enables the more powerful joint-bootstrap constructions.",
+            UserWarning,
+            stacklevel=4,
         )
-        if joint is None:
-            warnings.warn(
-                "PPI alignment: could not build a joint bootstrap distribution for "
-                "max-T simultaneous CIs (pairs don't share a common set of labeled "
-                "items, or fewer than 15 shared labeled items). Falling back to "
-                "Bonferroni for simultaneous CIs. Labeling the same items across "
-                "every entity enables the more powerful max-T correction.",
-                UserWarning,
-                stacklevel=4,
-            )
-        used_max_t = joint is not None
+
+    used_max_t = joint is not None and _need_joint_for_ci and resolved_prefer == "max_t"
+    used_boot = joint is not None and _need_joint_for_ci and resolved_prefer == "boot"
+    boot_M_b = _M_b_from_T(joint[3], joint[2]) if used_boot else None
+
+    used_romano_wolf = joint is not None and _need_joint_for_correction
+    romano_wolf_pvalues = (
+        _ppi_romano_wolf_pvalues_from_joint_stats(*joint, pair_keys)
+        if used_romano_wolf else None
+    )
+    # Shaffer's is the fallback correction whenever Romano-Wolf was resolved
+    # (by auto or explicitly) but couldn't actually run.
+    effective_correction = "shaffer" if resolved_correction == "romano_wolf" and not used_romano_wolf else resolved_correction
+
+    def _pair_alpha_for(level_alpha: float) -> float:
+        """Resolve the per-pair alpha (or shared effective alpha) a
+        dispatch call should use at a given confidence level, for both the
+        headline CI and every gradient-band CI -- keeping them consistent
+        with whichever simultaneous-CI construction is actually in effect."""
+        if not use_simultaneous:
+            return level_alpha
+        if used_boot:
+            return _ppi_alpha_eff_from_M_b(boot_M_b, 1.0 - level_alpha)
+        if resolved_prefer == "sidak":
+            return 1.0 - (1.0 - level_alpha) ** (1.0 / n_pairs)
+        return level_alpha / n_pairs  # Bonferroni (explicit, or any other fallback)
+
+    pair_alpha = _pair_alpha_for(alpha)
 
     final_diffs = np.empty(n_pairs, dtype=float)
     pair_ci_lo  = np.empty(n_pairs, dtype=float)
@@ -1387,7 +1633,7 @@ def _run_alignment_ppi(
         pair_pvals[k]  = res.p_value if res.p_value is not None else 1.0
 
         for a in GRADIENT_CI_ALPHAS:
-            g_alpha = a / n_pairs if use_simultaneous else a
+            g_alpha = _pair_alpha_for(a)
             g = dispatch(g_alpha, n_boot, rng)
             pair_multi_ci[a][(ea, eb)] = (g.ci_low, g.ci_high)
 
@@ -1410,35 +1656,49 @@ def _run_alignment_ppi(
         )
 
     # Multiple-comparison correction on marginal p-values (unaffected by the
-    # Bonferroni simultaneous-CI adjustment above, which only widens CIs).
-    # Skipped for p_value when max-T already applies below — max-T's p-value
-    # is already family-wise controlled via the joint null and would just be
-    # overwritten, exactly mirroring all_pairwise()'s non-PPI convention where
-    # a max-T p-value supersedes rather than stacks with this correction.
-    if correction != "none" and n_pairs > 1:
-        if not used_max_t:
-            pair_pvals = correct_pvalues(pair_pvals, correction, n_groups=len(labels))
+    # simultaneous-CI adjustment above, which only widens CIs). Skipped for
+    # pair_pvals when max-T or Romano-Wolf already applies below/here --
+    # both are already family-wise controlled via their own joint null and
+    # would just be overwritten, exactly mirroring all_pairwise()'s non-PPI
+    # convention where a max-T/Romano-Wolf p-value supersedes rather than
+    # stacks with correct_pvalues().
+    if effective_correction != "none" and n_pairs > 1:
+        if used_romano_wolf:
+            for k, key in enumerate(pair_keys):
+                pair_pvals[k] = romano_wolf_pvalues[key]
+        elif not used_max_t:
+            pair_pvals = correct_pvalues(pair_pvals, effective_correction, n_groups=len(labels))
 
-        # Companion Wilcoxon p-values always get this correction as their own
-        # family, regardless of max-T — matching all_pairwise()'s uncorrected
-        # path, which never applies max-T to wilcoxon_p (see its docstring).
+        # Companion Wilcoxon p-values always get their own correction as
+        # their own family, regardless of max-T/Romano-Wolf — matching
+        # all_pairwise()'s convention, which never applies either to
+        # wilcoxon_p (see its docstring). Romano-Wolf's joint construction
+        # is specific to the paired-mean/PPI estimand (point_ests/obs_se
+        # above) and has no Wilcoxon-signed-rank-compatible form, so
+        # Shaffer's (with Holm as the same subset-safe fallback the non-PPI
+        # path uses) substitutes whenever the primary correction is
+        # Romano-Wolf -- mirroring the non-PPI docstring's own statement
+        # that Wilcoxon "everywhere...except when Romano-Wolf is what
+        # resolved" note.
         wsr_keys = [key for key in pair_keys if pair_wilcoxon_p[key] is not None]
         if len(wsr_keys) > 1:
             wsr_vals = np.array([pair_wilcoxon_p[key] for key in wsr_keys], dtype=float)
+            _wsr_base = "shaffer" if effective_correction == "romano_wolf" else effective_correction
             # Shaffer's needs the complete n_groups*(n_groups-1)/2 all-pairs
             # set; wsr_keys can be a strict subset (e.g. no validated PPI
             # Wilcoxon for an unpaired-fallback pair -- see above). Holm has
             # no such requirement and is still FWER-valid for any subset.
             _wsr_correction = (
-                "holm" if correction == "shaffer" and len(wsr_keys) != len(labels) * (len(labels) - 1) // 2
-                else correction
+                "holm" if _wsr_base == "shaffer" and len(wsr_keys) != len(labels) * (len(labels) - 1) // 2
+                else _wsr_base
             )
             wsr_adj = correct_pvalues(wsr_vals, _wsr_correction, n_groups=len(labels))
             for key, adj_p in zip(wsr_keys, wsr_adj):
                 pair_wilcoxon_p[key] = float(adj_p)
 
     if used_max_t:
-        point_ests_j, obs_se_j, valid_pairs_j, M_b, t_obs_j = joint
+        point_ests_j, obs_se_j, valid_pairs_j, T_j, t_obs_j = joint
+        M_b = _M_b_from_T(T_j, valid_pairs_j)
         headline_ci, headline_p = _max_t_from_joint_stats(
             point_ests_j, obs_se_j, valid_pairs_j, M_b, t_obs_j, pair_keys, 1.0 - alpha,
         )
@@ -1492,8 +1752,23 @@ def _run_alignment_ppi(
     # Update bundle method metadata so summary() headers reflect the PPI method.
     bundle.resolved_method = pairwise_method
     bundle.resolved_ci_method = robustness_method
-    bundle.pairwise.simultaneous_ci_method = (
-        "max_t" if used_max_t else ("bonferroni" if use_simultaneous else None)
+    if used_max_t:
+        _sim_ci_label = "max_t"
+    elif used_boot:
+        _sim_ci_label = "boot"
+    elif use_simultaneous:
+        _sim_ci_label = "sidak" if resolved_prefer == "sidak" else "bonferroni"
+    else:
+        _sim_ci_label = None
+    bundle.pairwise.simultaneous_ci_method = _sim_ci_label
+    # correction_method must reflect the correction ACTUALLY applied to the
+    # final, PPI-corrected p-values -- previously left untouched here, so it
+    # silently kept whatever the initial non-PPI analyze() call had set
+    # (e.g. "romano_wolf" from the raw-score pass, even when PPI's own
+    # correction fell back to "shaffer"), which PairwiseMatrix.summary()
+    # displays via each pair's own .summary(correction=...).
+    bundle.pairwise.correction_method = (
+        effective_correction if (effective_correction != "none" and n_pairs > 1) else None
     )
 
     # ── Diagnostics ───────────────────────────────────────────────────────────
@@ -1574,14 +1849,19 @@ def _run_judge_alignment_if_needed(
         alignment_result=ar,
         alpha=alpha,
         n_boot=max(n_mc, 1000),
-        # Default "shaffer", not "auto": PPI-corrected p-values are a flat
-        # array here (no raw per-item diffs matrix in scope the way
-        # all_pairwise() has), so romano_wolf_stepdown_pvalues (which needs
-        # that matrix) isn't reachable from this path -- see
-        # _run_alignment_ppi's docstring. Shaffer's applies at any N and is
-        # already a real improvement on the previous "fdr_bh" (FDR, not
-        # FWER) default.
-        correction=engine_kwargs.get("correction", "shaffer"),
+        # Default "auto": resolves to Romano-Wolf step-down at N>=30 (see
+        # _ppi_romano_wolf_pvalues_from_joint_stats), falling back to
+        # Shaffer's below that threshold or when the required shared-
+        # labeled-item structure isn't available -- mirroring the non-PPI
+        # tree's own auto default exactly, now that a PPI-generalized
+        # Romano-Wolf exists. Validated across a 9-condition grid (k=3-5
+        # arms, N=50-200, label fractions 20-40%, binary data): worst-case
+        # FWER 0.067 vs nominal 0.05 (within normal MC noise, no systematic
+        # inflation), and power at or above Shaffer's in every condition
+        # tested (0/9 regressions) -- see tests/test_compound_ppi_fwer.py's
+        # TestRomanoWolfCalibration for the pytest-scale version of this
+        # check.
+        correction=engine_kwargs.get("correction", "auto"),
         method=engine_kwargs.get("method", "auto"),
         rng=engine_kwargs.get("rng"),
     )

--- a/evalstats/ppi.py
+++ b/evalstats/ppi.py
@@ -618,6 +618,13 @@ def _analytic_mean_point_se(
     """
     n_lab = len(Y_lab)
     n_all = len(Y_hat_unlab)
+    if n_all == 0:
+        raise ValueError(
+            "PPI correction requires at least one unlabeled item, got n_all=0 "
+            "(every item in this comparison is human-labeled, leaving no "
+            "unlabeled residual for the LLM-only term). If every item is "
+            "labeled, use the human labels directly instead of PPI correction."
+        )
 
     f_unlab = float(np.mean(Y_hat_unlab))
     f_lab = float(np.mean(Y_lab))

--- a/evalstats/tests/__init__.py
+++ b/evalstats/tests/__init__.py
@@ -2190,6 +2190,27 @@ def _ppi_paired_bayes_bootstrap(
     )
 
 
+def _ppi_require_unlabeled(n_all: int) -> None:
+    """Guard against a zero-length disjoint-unlabeled sample.
+
+    The two-term additive variance these ``_ppi_paired_*``/``_ppi_single_*``
+    functions use (``Var(unlabeled)/n_all + Var(rectifier)/n_lab``) divides
+    by ``n_all`` directly; without this check, an alignment set covering
+    every item (n_all=0) raises a bare ``ZeroDivisionError`` instead of an
+    actionable message. PPI's benefit comes from a large unlabeled pool plus
+    a small labeled subset -- if every item is labeled, there is no
+    LLM-only term left to correct and the human labels should be used
+    directly instead.
+    """
+    if n_all == 0:
+        raise ValueError(
+            "PPI correction requires at least one unlabeled item, got n_all=0 "
+            "(every item in this comparison is human-labeled, leaving no "
+            "unlabeled residual for the LLM-only term). If every item is "
+            "labeled, use the human labels directly instead of PPI correction."
+        )
+
+
 def _ppi_paired_bootstrap_t(
     a: np.ndarray,
     b: np.ndarray,
@@ -2248,6 +2269,7 @@ def _ppi_paired_bootstrap_t(
 
     n_all = len(diffs_unlab)
     n_lab = len(rect_items)
+    _ppi_require_unlabeled(n_all)
 
     # Below _MIN_LAB_RECOMMENDED, this function's own bootstrap-t is subject
     # to the SAME small-n_lab undercoverage as evalstats.ppi.correct's
@@ -2411,6 +2433,7 @@ def _ppi_paired_tango(
 
     n_all = len(diffs_unlab)
     n_lab = len(rect_items)
+    _ppi_require_unlabeled(n_all)
 
     f_unlab = float(np.mean(diffs_unlab))
     f_lab = float(np.mean(diffs_lab_true))
@@ -2487,6 +2510,7 @@ def _ppi_single_bootstrap_t(a: np.ndarray, a_lab: np.ndarray, alpha: float, n_bo
 
     n_all = len(values_unlab)
     n_lab = len(rect_items)
+    _ppi_require_unlabeled(n_all)
 
     f_unlab = float(np.mean(values_unlab))
     f_lab = float(np.mean(values_lab_true))
@@ -2624,6 +2648,7 @@ def _ppi_single_wilson(a: np.ndarray, a_lab: np.ndarray, alpha: float):
 
     n_all = len(values_unlab)
     n_lab = len(rect_items)
+    _ppi_require_unlabeled(n_all)
 
     f_unlab = float(np.mean(values_unlab))
     f_lab = float(np.mean(values_lab_true))

--- a/examples/compare_alignment_ppi_fwer.py
+++ b/examples/compare_alignment_ppi_fwer.py
@@ -1,0 +1,265 @@
+"""Compound scenario: PPI alignment correction layered on top of FWER
+(family-wise error rate) control, for a k >= 3 model comparison.
+
+Simulates a common real-world scenario:
+  - 4 models are scored by an LLM judge on 150 items each (cheap, scalable).
+  - A human annotator has labelled 60 of those items per model (expensive,
+    sparse) -- validate_alignment()/compare(alignment=...) use these to
+    debias the LLM-only estimates via Prediction-Powered Inference (PPI).
+  - With 4 models there are C(4,2) = 6 pairwise comparisons, so a family-wise
+    error rate (FWER) correction is also needed to avoid false positives
+    from testing 6 hypotheses at once (compare(..., simultaneous_ci=True,
+    correction=...)).
+
+This demonstrates that PPI correction and FWER control now compose
+correctly through the SAME compare() call: both the simultaneous-CI
+construction ("sidak" for small N, "boot" -- joint bootstrap with an
+effective alpha -- for larger N) AND the p-value correction ("shaffer" for
+small N, "romano_wolf" step-down for larger N) resolve automatically on top
+of the PPI-corrected estimates, matching evalstats' decision tree exactly --
+not just on raw LLM scores, and not silently downgraded to a weaker
+fallback.
+
+Prints four side-by-side comparisons so you can see what each layer costs:
+  1. Uncorrected      -- raw LLM scores, no PPI, no FWER control
+  2. PPI-only         -- judge-bias corrected, but no FWER control
+  3. FWER-only        -- raw LLM scores, FWER-controlled across all 6 pairs
+  4. Compound         -- PPI-corrected AND FWER-controlled together
+
+Usage:
+    python examples/compare_alignment_ppi_fwer.py
+"""
+
+import numpy as np
+import pandas as pd
+
+import evalstats as es
+
+# ── Simulation parameters ─────────────────────────────────────────────────────
+
+rng = np.random.default_rng(7)
+
+N_ITEMS   = 150   # items per model
+N_LABELED = 60    # items per model with human annotation (40% labeled)
+
+# True human pass rates (what an unbiased judge would measure)
+TRUE_RATE = {
+    "model_A": 0.70,
+    "model_B": 0.55,
+    "model_C": 0.48,
+    "model_D": 0.40,
+}
+
+# LLM judge parameters (True/False Positive Rate). model_A's judge is
+# noticeably biased (high false-positive rate) -- the other three have a
+# more evenly-noisy judge.
+LLM_TPR = {"model_A": 0.90, "model_B": 0.85, "model_C": 0.85, "model_D": 0.85}
+LLM_FPR = {"model_A": 0.55, "model_B": 0.20, "model_C": 0.20, "model_D": 0.20}
+
+HUMAN_ACCURACY = 0.95  # near-perfect human rater
+
+# ── Build the full dataset ────────────────────────────────────────────────────
+# Each (model, item) pair has a latent true quality (1 = pass, 0 = fail).
+# The LLM and human both observe the same item, producing correlated scores.
+
+rows = []
+# The SAME items are human-labeled for every model (paired by input) -- this
+# is what lets a simultaneous-CI construction that accounts for correlation
+# between pairs (evalstats' "boot": joint bootstrap with an effective alpha)
+# actually engage. Labeling a different random subset of items per model
+# (as you might if annotators are assigned per-model rather than per-item)
+# leaves too little item overlap between pairs for that joint construction,
+# and evalstats falls back to the (still valid, just more conservative)
+# Bonferroni construction instead -- with a UserWarning explaining why.
+gold_indices = rng.choice(N_ITEMS, size=N_LABELED, replace=False)
+
+for model in TRUE_RATE:
+    true_rate = TRUE_RATE[model]
+    tpr = LLM_TPR[model]
+    fpr = LLM_FPR[model]
+
+    quality = rng.binomial(1, true_rate, N_ITEMS)
+
+    human_score = np.where(
+        quality == 1,
+        rng.binomial(1, HUMAN_ACCURACY, N_ITEMS),
+        rng.binomial(1, 1 - HUMAN_ACCURACY, N_ITEMS),
+    ).astype(float)
+
+    llm_score = np.where(
+        quality == 1,
+        rng.binomial(1, tpr, N_ITEMS),
+        rng.binomial(1, fpr, N_ITEMS),
+    ).astype(float)
+
+    for item_id in range(N_ITEMS):
+        rows.append({
+            "model": model,
+            "item": item_id,
+            "llm_score": llm_score[item_id],
+            "human_score": float("nan"),  # filled in below for labeled items
+        })
+
+    for idx in gold_indices:
+        row_loc = len(rows) - N_ITEMS + idx
+        rows[row_loc]["human_score"] = human_score[idx]
+
+df = pd.DataFrame(rows)
+evaldata = es.load_from(df, col_map={"model": "model", "item": "item"})
+
+print("Simulation check — LLM win rates (expected vs actual):")
+for model in TRUE_RATE:
+    m = df[df["model"] == model]
+    llm_mean = m["llm_score"].mean()
+    human_mean = m["human_score"].dropna().mean()
+    exp_llm = LLM_TPR[model] * TRUE_RATE[model] + LLM_FPR[model] * (1 - TRUE_RATE[model])
+    print(f"  {model}: true={TRUE_RATE[model]:.2f}  "
+          f"llm_all={llm_mean:.3f} (expected≈{exp_llm:.3f})  "
+          f"human_labeled={human_mean:.3f}")
+print()
+
+# ── Validate alignment ────────────────────────────────────────────────────────
+
+print("=" * 70)
+print("STEP 1 — Validate LLM judge alignment")
+print("=" * 70)
+
+ar = es.validate_alignment(
+    evaldata,
+    llm_metric="llm_score",
+    human_groundtruth="human_score",
+)
+ar.summary()
+
+# ── 1. Uncorrected: raw LLM scores, no PPI, no FWER control ──────────────────
+
+print("=" * 70)
+print("STEP 2 — Uncorrected  (raw LLM scores, no PPI, no FWER control)")
+print("=" * 70)
+
+result_raw = es.compare(
+    evaldata,
+    factors="model",
+    metric="llm_score",
+    simultaneous_ci=False,
+    correction="none",
+    rng=np.random.default_rng(1),
+)
+result_raw.summary()
+
+# ── 2. PPI-only: judge-bias corrected, but no FWER control ───────────────────
+
+print("=" * 70)
+print("STEP 3 — PPI-only  (judge-bias corrected, no FWER control)")
+print("=" * 70)
+
+result_ppi_only = es.compare(
+    evaldata,
+    factors="model",
+    metric="llm_score",
+    alignment={"llm_score": ar},
+    simultaneous_ci=False,
+    correction="none",
+    rng=np.random.default_rng(2),
+)
+result_ppi_only.summary()
+
+# ── 3. FWER-only: raw LLM scores, FWER-controlled across all 6 pairs ────────
+
+print("=" * 70)
+print("STEP 4 — FWER-only  (raw LLM scores, FWER-controlled)")
+print("=" * 70)
+
+result_fwer_only = es.compare(
+    evaldata,
+    factors="model",
+    metric="llm_score",
+    simultaneous_ci=True,
+    correction="auto",
+    rng=np.random.default_rng(3),
+)
+result_fwer_only.summary()
+bundle_fwer_only = result_fwer_only._primary_bundle()
+print(f"  -> simultaneous_ci_method resolved to: "
+      f"{bundle_fwer_only.pairwise.simultaneous_ci_method!r}")
+print(f"  -> correction_method resolved to:      "
+      f"{bundle_fwer_only.pairwise.correction_method!r}")
+print()
+
+# ── 4. Compound: PPI-corrected AND FWER-controlled together ─────────────────
+
+print("=" * 70)
+print("STEP 5 — Compound  (PPI-corrected AND FWER-controlled)")
+print("=" * 70)
+print(f"  ({N_LABELED} human labels per model, {len(TRUE_RATE)} models -> "
+      f"{len(TRUE_RATE) * (len(TRUE_RATE) - 1) // 2} pairwise comparisons)")
+print()
+
+result_compound = es.compare(
+    evaldata,
+    factors="model",
+    metric="llm_score",
+    alignment={"llm_score": ar},
+    simultaneous_ci=True,
+    correction="auto",
+    rng=np.random.default_rng(4),
+)
+result_compound.summary()
+bundle_compound = result_compound._primary_bundle()
+print(f"  -> resolved pairwise method:           {bundle_compound.resolved_method!r}")
+print(f"  -> simultaneous_ci_method resolved to: "
+      f"{bundle_compound.pairwise.simultaneous_ci_method!r}")
+print(f"  -> correction_method resolved to:      "
+      f"{bundle_compound.pairwise.correction_method!r}")
+print("     (these now default to the same constructions (\"sidak\"/\"boot\" for")
+print("      CIs, \"shaffer\"/\"romano_wolf\" for p-values) the non-PPI path uses,")
+print("      matching evalstats' FWER decision tree -- neither gets silently")
+print("      stuck at a weaker fallback (Bonferroni-only / Shaffer-only).)")
+print()
+
+# ── 5. Side-by-side summary of point estimates and pairwise verdicts ────────
+
+print("=" * 70)
+print("STEP 6 — Point estimates: raw vs PPI-only vs true rate")
+print("=" * 70)
+
+labels = list(bundle_compound.benchmark.template_labels)
+bundle_raw = result_raw._primary_bundle()
+bundle_ppi_only = result_ppi_only._primary_bundle()
+
+print(f"  {'Model':<10}  {'Raw LLM':>9}  {'PPI-only':>9}  {'Compound':>9}  {'True rate':>9}")
+print("  " + "-" * 58)
+for i, lbl in enumerate(labels):
+    raw_est = bundle_raw.robustness.mean[i]
+    ppi_est = bundle_ppi_only.robustness.mean[i]
+    compound_est = bundle_compound.robustness.mean[i]
+    true_r = TRUE_RATE.get(lbl, float("nan"))
+    print(f"  {lbl:<10}  {raw_est:>8.3f}   {ppi_est:>8.3f}   {compound_est:>8.3f}   {true_r:>8.3f}")
+print()
+
+print("=" * 70)
+print("STEP 7 — A note on what to expect")
+print("=" * 70)
+print("""
+  PPI correction and FWER control both cost some detection power on their
+  own -- and applied together, that cost compounds. Each layer independently
+  spends some of the marginal estimate's "headroom" below the significance
+  threshold (PPI by adding judge-noise-correction variance; FWER control by
+  widening CIs / inflating p-values to hold across every comparison). At
+  realistic label fractions (PPI is designed for sparse, expensive human
+  labels -- often 10-20% of items, not the 40% used here for a clearer demo)
+  and moderate judge agreement, don't be surprised if the compound path
+  detects a real difference far less often than either layer would in
+  isolation. This isn't a bug in evalstats -- it's the honest cost of
+  controlling two different error sources at once with a finite labeled
+  sample.
+
+  "romano_wolf" (the default p-value correction at N>=30) does recover some
+  of that cost back versus the older "shaffer"-only default -- validated
+  across a grid of arm counts/N/label fractions to be at least as powerful
+  as Shaffer's in every condition tested, never worse -- but it's a real,
+  bounded improvement, not a fix: it typically recovers a modest fraction
+  of the gap, not all of it. The most reliable way to recover the rest is
+  still more (or better-agreeing) human labels, not a different correction
+  method.
+""")

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -941,6 +941,39 @@ class TestPPISampleSizeChecks:
             es.compare(evaldata, factors="model", metric="llm_score",
                        alignment={"llm_score": ar})
 
+    def test_raises_clear_error_when_entity_is_100pct_labeled(self):
+        """An entity with EVERY item human-labeled has zero unlabeled
+        residual left for the LLM-only term (n_all=0 in the PPI variance
+        decomposition Var(unlab)/n_all + Var(rectifier)/n_lab). This used to
+        raise a bare ZeroDivisionError from deep inside
+        evalstats.tests._ppi_single_wilson/_ppi_paired_tango; it should now
+        raise a clear, actionable ValueError instead."""
+        rng = np.random.default_rng(7)
+        n_items = 60
+        df = pd.DataFrame({
+            "model": ["A"] * n_items + ["B"] * n_items,
+            "item": list(range(n_items)) * 2,
+            "llm_score": np.concatenate([
+                rng.binomial(1, 0.70, n_items),
+                rng.binomial(1, 0.45, n_items),
+            ]).astype(float),
+        })
+        human = np.full(len(df), np.nan)
+        # Every item for model A is labeled (n_all=0 for A); model B stays
+        # fully unlabeled so this isolates the single-arm (robustness) path.
+        a_mask = df["model"] == "A"
+        human[a_mask] = df.loc[a_mask, "llm_score"]
+        df["human_score"] = human
+        evaldata = es.load_from(df, col_map={"model": "model", "item": "item"})
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score",
+                                    human_groundtruth="human_score")
+        with pytest.raises(ValueError, match="at least one unlabeled item"):
+            es.compare(evaldata, factors="model", metric="llm_score",
+                       alignment={"llm_score": ar})
+
     def test_no_size_warnings_above_thresholds(self):
         """No size warnings when n_labeled ≥ 30 and N ≥ 100."""
         evaldata, metric = _make_binary_evaldata(n_items=60, n_labeled=35)

--- a/tests/test_compound_ppi_fwer.py
+++ b/tests/test_compound_ppi_fwer.py
@@ -1,0 +1,835 @@
+"""Tests for the COMPOUND scenario: PPI alignment correction layered on top
+of FWER-controlled (simultaneous-CI / multiple-comparison-corrected)
+pairwise results, via the compare(alignment=..., simultaneous_ci=..., correction=...)
+path.
+
+This is the "real practice" case none of the existing calibration sweeps
+(simulations/sim_alignment_methods.py, simulations/sim_type_i_calibration.py)
+exercise end-to-end: those validate PPI correction and FWER correction each
+in isolation (2-arm PPI-only, or k-arm FWER-only on raw LLM scores), never
+both stacked together on a k>=3 comparison with a noisy judge and sparse
+human labels. See evalstats/api.py's ``_run_alignment_ppi`` docstring for
+what this compound path's simultaneous-CI resolution (sidak/boot, mirroring
+the non-PPI decision tree) does and doesn't have harness-scale validation
+for yet.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+
+import evalstats as es
+from evalstats.alignment import validate_alignment
+
+
+def _rng(seed: int = 0) -> np.random.Generator:
+    return np.random.default_rng(seed)
+
+
+# ---------------------------------------------------------------------------
+# Data generators
+# ---------------------------------------------------------------------------
+
+def _make_multiarm_binary(
+    n_entities: int = 3,
+    n_items: int = 150,
+    n_labeled: int = 60,
+    p_base: float = 0.55,
+    effect_size: float = 0.0,
+    agreement_rate: float = 0.85,
+    seed: int = 0,
+):
+    """k-arm binary data with human labels on the SAME item positions for
+    every entity, so every pair has full labeled-item overlap (the PPI
+    "dispatch" branch -- see _run_alignment_ppi's pair_branch classification).
+
+    ``effect_size=0.0`` gives a true null (every arm has the same success
+    probability); a positive value spreads arm probabilities evenly around
+    ``p_base`` for a power check.
+    """
+    rng = _rng(seed)
+    if effect_size == 0.0:
+        probs = np.full(n_entities, p_base)
+    else:
+        probs = np.linspace(p_base - effect_size / 2, p_base + effect_size / 2, n_entities)
+    rows = []
+    for i in range(n_entities):
+        lbl = f"M{i}"
+        vals = rng.binomial(1, probs[i], n_items).astype(float)
+        for j in range(n_items):
+            rows.append((lbl, j, vals[j]))
+    df = pd.DataFrame(rows, columns=["model", "item", "llm_score"])
+
+    human = np.full(len(df), np.nan)
+    labeled_items = rng.choice(n_items, size=n_labeled, replace=False)
+    mask = df["item"].isin(labeled_items)
+    idxs = df.index[mask]
+    agree = rng.random(len(idxs)) < agreement_rate
+    human[idxs] = np.where(agree, df.loc[idxs, "llm_score"], 1.0 - df.loc[idxs, "llm_score"])
+    df["human_score"] = human
+
+    evaldata = es.load_from(df, col_map={"model": "model", "item": "item"})
+    return evaldata
+
+
+def _make_multiarm_continuous(
+    n_entities: int = 3,
+    n_items: int = 200,
+    n_labeled: int = 80,
+    seed: int = 0,
+):
+    """k-arm [0,1]-bounded continuous data, fully shared labeled positions
+    across every entity (all pairs "dispatch")."""
+    rng = _rng(seed)
+    means = np.linspace(0.55, 0.75, n_entities)
+    rows = []
+    for i in range(n_entities):
+        lbl = f"M{i}"
+        vals = np.clip(rng.normal(means[i], 0.12, n_items), 0, 1)
+        for j in range(n_items):
+            rows.append((lbl, j, vals[j]))
+    df = pd.DataFrame(rows, columns=["model", "item", "llm_score"])
+
+    human = np.full(len(df), np.nan)
+    labeled_items = rng.choice(n_items, size=n_labeled, replace=False)
+    mask = df["item"].isin(labeled_items)
+    idxs = df.index[mask]
+    human[idxs] = np.clip(df.loc[idxs, "llm_score"] + rng.normal(0, 0.05, len(idxs)), 0, 1)
+    df["human_score"] = human
+
+    evaldata = es.load_from(df, col_map={"model": "model", "item": "item"})
+    return evaldata
+
+
+def _make_mixed_branch_binary(n_items: int = 150, seed: int = 0):
+    """4-arm binary data where M0/M1/M2 share full labeled-item overlap
+    ("dispatch") but M3's labels come from a disjoint, sub-threshold set of
+    items -- every pair touching M3 has zero overlap AND fewer than 15 of
+    M3's own labels, so it lands in the "skip" branch (kept uncorrected).
+
+    Exercises the fact that a single compound compare() call can return a
+    HETEROGENEOUS mix of PPI-corrected and un-corrected pairs.
+    """
+    rng = _rng(seed)
+    entities = ["M0", "M1", "M2", "M3"]
+    rows = []
+    for lbl in entities:
+        vals = rng.binomial(1, 0.55, n_items).astype(float)
+        for j in range(n_items):
+            rows.append((lbl, j, vals[j]))
+    df = pd.DataFrame(rows, columns=["model", "item", "llm_score"])
+
+    human = np.full(len(df), np.nan)
+    shared_items = rng.choice(n_items, size=60, replace=False)
+    remaining = np.setdiff1d(np.arange(n_items), shared_items)
+    m3_items = rng.choice(remaining, size=8, replace=False)
+
+    for lbl, items in (("M0", shared_items), ("M1", shared_items), ("M2", shared_items), ("M3", m3_items)):
+        mask = (df["model"] == lbl) & (df["item"].isin(items))
+        idxs = df.index[mask]
+        agree = rng.random(len(idxs)) < 0.85
+        human[idxs] = np.where(agree, df.loc[idxs, "llm_score"], 1.0 - df.loc[idxs, "llm_score"])
+    df["human_score"] = human
+
+    evaldata = es.load_from(df, col_map={"model": "model", "item": "item"})
+    return evaldata, ["M0", "M1", "M2", "M3"]
+
+
+# ---------------------------------------------------------------------------
+# Structural / plumbing tests (fast, deterministic where possible)
+# ---------------------------------------------------------------------------
+
+class TestCompoundStructuralPlumbing:
+    def test_simultaneous_ci_flag_and_valid_output_survive_ppi(self):
+        """simultaneous_ci=True + alignment= together still produce a fully
+        valid pairwise matrix: flag preserved, every CI ordered/finite, every
+        p-value in [0, 1]."""
+        evaldata = _make_multiarm_binary(n_entities=3, seed=10)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=True, correction="shaffer",
+            )
+        bundle = result._primary_bundle()
+        assert bundle.pairwise.simultaneous_ci is True
+        assert bundle.ppi_applied is True
+        for pr in bundle.pairwise.results.values():
+            assert np.isfinite(pr.ci_low) and np.isfinite(pr.ci_high)
+            assert pr.ci_low <= pr.ci_high
+            assert 0.0 <= pr.p_value <= 1.0
+
+    def test_bonferroni_pair_alpha_widens_ppi_cis_vs_non_simultaneous(self):
+        """Forcing a specific PPI method (deterministic, closed-form 'tango'),
+        simultaneous_ci=True must divide alpha by n_pairs and thus produce
+        strictly wider (or equal, in a degenerate case) CIs than
+        simultaneous_ci=False on the identical data."""
+        evaldata = _make_multiarm_binary(n_entities=3, seed=11)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+
+            result_sim = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30, method="tango",
+                simultaneous_ci=True, correction="none",
+            )
+            result_nosim = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30, method="tango",
+                simultaneous_ci=False, correction="none",
+            )
+
+        pw_sim = result_sim._primary_bundle().pairwise
+        pw_nosim = result_nosim._primary_bundle().pairwise
+        assert pw_sim.simultaneous_ci is True
+        assert pw_nosim.simultaneous_ci is False
+
+        widths_sim = {k: (v.ci_high - v.ci_low) for k, v in pw_sim.results.items()}
+        widths_nosim = {k: (v.ci_high - v.ci_low) for k, v in pw_nosim.results.items()}
+        for key in widths_sim:
+            assert widths_sim[key] >= widths_nosim[key] - 1e-9, (
+                f"Pair {key}: simultaneous width {widths_sim[key]} should be >= "
+                f"non-simultaneous width {widths_nosim[key]}"
+            )
+        # At least one pair should be strictly wider (guards against the
+        # widening being silently a no-op).
+        assert any(widths_sim[k] > widths_nosim[k] + 1e-9 for k in widths_sim)
+
+    def test_correction_only_changes_pvalues_not_cis(self):
+        """correction= (p-value FWER control) and simultaneous_ci= (CI
+        widening) are independent knobs -- correction must NOT move the CI
+        bounds, only the p-values, matching the non-PPI convention documented
+        in _run_alignment_ppi (Bonferroni CI construction vs. p-value
+        correction being separate steps)."""
+        evaldata = _make_multiarm_binary(n_entities=3, seed=12)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+
+            # Both calls share a seeded rng: at this N (150/entity, binary),
+            # simultaneous_ci=True now resolves to "boot" (joint bootstrap
+            # with an effective alpha, per the paper's decision tree), which
+            # is stochastic -- an unseeded rng would make the two calls'
+            # CIs differ for a reason unrelated to correction=.
+            result_none = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30, method="tango",
+                simultaneous_ci=True, correction="none", rng=_rng(112),
+            )
+            result_shaffer = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30, method="tango",
+                simultaneous_ci=True, correction="shaffer", rng=_rng(112),
+            )
+
+        pw_none = result_none._primary_bundle().pairwise
+        pw_shaffer = result_shaffer._primary_bundle().pairwise
+        for key in pw_none.results:
+            r_none = pw_none.results[key]
+            r_shaffer = pw_shaffer.results[key]
+            assert abs(r_none.ci_low - r_shaffer.ci_low) < 1e-12
+            assert abs(r_none.ci_high - r_shaffer.ci_high) < 1e-12
+            # Shaffer's correction can only make p-values >= the uncorrected ones.
+            assert r_shaffer.p_value >= r_none.p_value - 1e-12
+
+    def test_default_auto_reaches_boot_at_n_ge_30(self):
+        """The compound path's default (method="auto", prefer="auto") now
+        mirrors the paper's decision tree: at N >= 30 (numeric, non-lopsided)
+        it resolves to "boot" (joint bootstrap with an effective alpha)
+        widening whichever closed-form PPI method resolved (ppi_logit_t here),
+        not a silent, permanent Bonferroni downgrade. See
+        _ppi_alpha_eff_from_M_b / resolve_auto_simultaneous_ci_method."""
+        evaldata = _make_multiarm_continuous(n_entities=3, n_items=200, n_labeled=80, seed=13)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=True, correction="shaffer", rng=_rng(13),
+                # method="auto" (default), prefer="auto" (default)
+            )
+        bundle = result._primary_bundle()
+        assert bundle.resolved_method in ("ppi_logit_t", "ppi_t_interval")
+        assert bundle.pairwise.simultaneous_ci_method == "boot"
+
+    def test_default_auto_reaches_sidak_below_n_threshold(self):
+        """Below the tree's N threshold, "auto" resolves to "sidak" (a pure
+        closed-form alpha adjustment), not Bonferroni -- matching the
+        non-PPI path's small-N branch instead of a narrower PPI-only
+        fallback."""
+        evaldata = _make_multiarm_continuous(n_entities=3, n_items=25, n_labeled=15, seed=131)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=True, correction="shaffer",
+                # method="auto" (default), prefer="auto" (default)
+            )
+        bundle = result._primary_bundle()
+        assert bundle.pairwise.simultaneous_ci_method == "sidak"
+
+    def test_method_bootstrap_t_uses_boot_not_max_t_under_auto(self):
+        """Forcing method="bootstrap_t" under the default prefer="auto" now
+        gets the SAME "boot" (joint-bootstrap-with-effective-alpha) treatment
+        as every other method, not a special full max-T construction --
+        max_t is never an auto-resolved outcome (matches evalstats' decision
+        tree, which has no max-T node at all, and the non-PPI
+        _simultaneous_cis_router's identical convention: max_t is reachable
+        only via an explicit, literal prefer="max_t" request)."""
+        evaldata = _make_multiarm_binary(n_entities=3, n_items=150, n_labeled=60, seed=14)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=50, method="bootstrap_t",
+                simultaneous_ci=True, correction="shaffer",
+                rng=_rng(14),
+            )
+        bundle = result._primary_bundle()
+        assert bundle.pairwise.simultaneous_ci_method == "boot"
+        for pr in bundle.pairwise.results.values():
+            assert np.isfinite(pr.ci_low) and np.isfinite(pr.ci_high)
+            assert pr.ci_low <= pr.ci_high
+            assert 0.0 <= pr.p_value <= 1.0
+
+    def test_prefer_kwarg_is_not_forwarded_through_compare(self):
+        """compare(alignment=..., prefer=...) does not raise, but silently
+        drops prefer= as an unrecognized keyword -- it has no effect on the
+        PPI simultaneous-CI construction. This documents a real gap: there is
+        currently no way for a compare() caller to force
+        prefer="bonferroni"/"max_t"/"sidak"/"boot" for the PPI path directly
+        (unlike the non-PPI all_pairwise()/analyze() path, where prefer= IS a
+        recognized engine kwarg) -- only the internal, private
+        _run_alignment_ppi function accepts it (see
+        test_explicit_max_t_reachable_via_private_function below)."""
+        evaldata = _make_multiarm_binary(n_entities=3, n_items=150, n_labeled=60, seed=141)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=50, method="bootstrap_t",
+                simultaneous_ci=True, correction="shaffer", prefer="max_t",
+                rng=_rng(141),
+            )
+        messages = [str(w.message) for w in caught]
+        assert any("unknown keyword argument 'prefer'" in m for m in messages), messages
+        bundle = result._primary_bundle()
+        # Still resolves to "boot" via the auto tree -- prefer="max_t" was
+        # NOT honored, confirming it has no effect through compare().
+        assert bundle.pairwise.simultaneous_ci_method == "boot"
+
+    def test_explicit_max_t_reachable_via_private_function(self):
+        """max_t is a real, working construction -- just not reachable from
+        the public compare() API (see test_prefer_kwarg_is_not_forwarded_
+        through_compare). Calling the private _run_alignment_ppi directly
+        with prefer="max_t" (mirroring how the non-PPI all_pairwise() DOES
+        expose prefer= publicly) confirms it still resolves correctly."""
+        from evalstats.api import _run_alignment_ppi
+        from evalstats.loader import load_from as _load_from
+
+        evaldata = _make_multiarm_binary(n_entities=3, n_items=150, n_labeled=60, seed=142)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                method="bootstrap_t", simultaneous_ci=True, correction="shaffer",
+            )
+            df = evaldata._df.copy()
+            _run_alignment_ppi(
+                result, df=df, metric_col="llm_score", factor_col="model", item_col="item",
+                alignment_result=ar, alpha=0.05, n_boot=1000, correction="shaffer",
+                method="bootstrap_t", rng=_rng(142), prefer="max_t",
+            )
+        bundle = result._primary_bundle()
+        assert bundle.pairwise.simultaneous_ci_method == "max_t"
+        for pr in bundle.pairwise.results.values():
+            assert np.isfinite(pr.ci_low) and np.isfinite(pr.ci_high)
+            assert pr.ci_low <= pr.ci_high
+            assert 0.0 <= pr.p_value <= 1.0
+
+    def test_max_t_silently_falls_back_to_bonferroni_when_overlap_insufficient(self):
+        """When some pairs lack the shared-labeled-item structure max-T needs
+        (fallback/skip branches present for pairs touching M3), the compound
+        path falls back to Bonferroni for the WHOLE comparison (max-T is all-
+        or-nothing across pairs) -- but, unlike the "labeled positions don't
+        match across pairs" case internal to _ppi_bootstrap_t_joint_stats,
+        this specific pre-emptive fallback (via the `not fallback_pairs and
+        not skipped_pairs` guard) does NOT emit its own explanatory warning.
+        The only warnings raised are the generic fallback/skip notices already
+        covered by test_skipped_pair_stays_uncorrected_while_others_are_ppi_corrected.
+        This is worth knowing operationally: a user won't be told *why* they
+        didn't get max-T in this case, only that some pairs used a weaker
+        correction."""
+        evaldata, _labels = _make_mixed_branch_binary(seed=15)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=50, method="bootstrap_t",
+                simultaneous_ci=True, correction="shaffer",
+                rng=_rng(15),
+            )
+        bundle = result._primary_bundle()
+        assert bundle.pairwise.simultaneous_ci_method == "bonferroni"
+        messages = [str(w.message) for w in caught]
+        assert not any("Falling back to Bonferroni" in m for m in messages), messages
+
+    def test_skipped_pair_stays_uncorrected_while_others_are_ppi_corrected(self):
+        """In the mixed-branch dataset, pairs touching M3 (insufficient
+        overlap) must keep their un-annotated, non-PPI test_method, while
+        every pair among M0/M1/M2 (full overlap) must be PPI-corrected --
+        i.e. a single compound compare() result can legitimately be a
+        heterogeneous mix of corrected/uncorrected pairs."""
+        evaldata, labels = _make_mixed_branch_binary(seed=16)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=True, correction="shaffer",
+            )
+        bundle = result._primary_bundle()
+        for (a, b), pr in bundle.pairwise.results.items():
+            touches_m3 = "M3" in (a, b)
+            if touches_m3:
+                assert "PPI" not in pr.test_method, (a, b, pr.test_method)
+            else:
+                assert "PPI" in pr.test_method, (a, b, pr.test_method)
+
+    def test_two_arm_compound_does_not_widen_for_fwer(self):
+        """With only one pair (k=2 arms), use_simultaneous is False regardless
+        of the simultaneous_ci= flag (no family to control) -- CIs should
+        match the non-simultaneous call exactly."""
+        evaldata = _make_multiarm_binary(n_entities=2, seed=17)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result_sim = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30, method="tango",
+                simultaneous_ci=True, correction="none",
+            )
+            result_nosim = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30, method="tango",
+                simultaneous_ci=False, correction="none",
+            )
+        pw_sim = result_sim._primary_bundle().pairwise
+        pw_nosim = result_nosim._primary_bundle().pairwise
+        for key in pw_sim.results:
+            assert abs(pw_sim.results[key].ci_low - pw_nosim.results[key].ci_low) < 1e-12
+            assert abs(pw_sim.results[key].ci_high - pw_nosim.results[key].ci_high) < 1e-12
+
+    def test_correction_auto_resolves_instead_of_crashing(self):
+        """compare(alignment=..., correction="auto") must not crash.
+
+        Regression test: correction="auto" is the non-PPI path's own
+        default and a perfectly reasonable thing to pass explicitly, but
+        _run_alignment_ppi used to forward "auto" straight into
+        correct_pvalues() (which has no "auto" case of its own -- only
+        all_pairwise()'s non-PPI path pre-resolves "auto" before reaching
+        it), raising "ValueError: Unknown correction method: auto". At
+        N=150 (>= the auto tree's N>=30 threshold), "auto" now resolves to
+        "romano_wolf" (see TestRomanoWolfPvalues), not "shaffer" -- this
+        test just confirms the crash is gone and every p-value is valid,
+        regardless of which correction resolved."""
+        evaldata = _make_multiarm_binary(n_entities=3, n_items=150, n_labeled=60, seed=143)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=True, correction="auto",
+                rng=_rng(143),
+            )
+        bundle = result._primary_bundle()
+        for pr in bundle.pairwise.results.values():
+            assert 0.0 <= pr.p_value <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# PPI-generalized Romano-Wolf step-down p-values (structural tests)
+# ---------------------------------------------------------------------------
+# Romano-Wolf's step-down refinement reuses the SAME joint bootstrap
+# resample "boot" (simultaneous CIs) already needs -- see
+# _ppi_romano_wolf_pvalues_from_joint_stats in evalstats/api.py -- so it
+# shares that construction's requirements: every pair must be "dispatch"
+# branch (full shared-labeled-item overlap), with >= 15 shared labeled
+# items. Falls back to Shaffer's when that structure isn't available,
+# mirroring "boot"'s own degrade-to-Bonferroni precedent.
+
+class TestRomanoWolfPvalues:
+    def test_explicit_romano_wolf_produces_valid_pvalues(self):
+        evaldata = _make_multiarm_binary(n_entities=4, n_items=150, n_labeled=60, seed=200)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=False, correction="romano_wolf",
+                rng=_rng(200),
+            )
+        bundle = result._primary_bundle()
+        assert bundle.pairwise.correction_method == "romano_wolf"
+        for pr in bundle.pairwise.results.values():
+            assert 0.0 <= pr.p_value <= 1.0
+
+    def test_auto_resolves_to_romano_wolf_at_n_ge_30(self):
+        """Mirrors the non-PPI decision tree: correction="auto" resolves to
+        Romano-Wolf at N >= 30 (numeric) when the shared-structure
+        requirement is met, not just Shaffer's regardless of N."""
+        evaldata = _make_multiarm_binary(n_entities=4, n_items=100, n_labeled=40, seed=201)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=False, correction="auto",
+                rng=_rng(201),
+            )
+        bundle = result._primary_bundle()
+        assert bundle.pairwise.correction_method == "romano_wolf"
+
+    def test_auto_resolves_to_shaffer_below_n_30(self):
+        evaldata = _make_multiarm_binary(n_entities=4, n_items=25, n_labeled=15, seed=202)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=False, correction="auto",
+                rng=_rng(202),
+            )
+        bundle = result._primary_bundle()
+        assert bundle.pairwise.correction_method == "shaffer"
+
+    def test_romano_wolf_falls_back_to_shaffer_when_overlap_insufficient(self):
+        """When some pairs lack the shared-labeled-item structure Romano-Wolf
+        needs (fallback/skip branches present for pairs touching M3), the
+        whole comparison's p-value correction falls back to Shaffer's --
+        Romano-Wolf is all-or-nothing across pairs, same as "boot"."""
+        evaldata, _labels = _make_mixed_branch_binary(seed=203)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=False, correction="romano_wolf",
+                rng=_rng(203),
+            )
+        bundle = result._primary_bundle()
+        assert bundle.pairwise.correction_method == "shaffer"
+        for pr in bundle.pairwise.results.values():
+            assert 0.0 <= pr.p_value <= 1.0
+
+    def test_wilcoxon_companion_pvalues_use_shaffer_not_romano_wolf(self):
+        """Romano-Wolf's joint construction is specific to the paired-mean/
+        PPI estimand and has no Wilcoxon-signed-rank-compatible form (same
+        as the non-PPI path) -- the companion wilcoxon_p correction must
+        substitute Shaffer's (or Holm for a subset) rather than crash trying
+        to pass "romano_wolf" into correct_pvalues(), which doesn't know
+        that method name."""
+        evaldata = _make_multiarm_binary(n_entities=4, n_items=150, n_labeled=60, seed=204)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=False, correction="romano_wolf",
+                rng=_rng(204),
+            )
+        bundle = result._primary_bundle()
+        for pr in bundle.pairwise.results.values():
+            if pr.wilcoxon_p is not None:
+                assert 0.0 <= pr.wilcoxon_p <= 1.0
+
+    def test_correction_method_field_reflects_actual_correction(self):
+        """bundle.pairwise.correction_method must reflect the correction
+        ACTUALLY applied to the final PPI-corrected p-values -- previously
+        left untouched by _run_alignment_ppi, so it silently kept whatever
+        the initial non-PPI analyze() pass had set."""
+        evaldata = _make_multiarm_binary(n_entities=4, n_items=150, n_labeled=60, seed=205)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result_none = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=False, correction="none",
+                rng=_rng(205),
+            )
+            result_shaffer = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=False, correction="shaffer",
+                rng=_rng(205),
+            )
+            result_rw = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=False, correction="romano_wolf",
+                rng=_rng(205),
+            )
+        assert result_none._primary_bundle().pairwise.correction_method is None
+        assert result_shaffer._primary_bundle().pairwise.correction_method == "shaffer"
+        assert result_rw._primary_bundle().pairwise.correction_method == "romano_wolf"
+
+    def test_romano_wolf_reuses_joint_resample_shared_with_boot(self):
+        """When BOTH simultaneous_ci=True (resolving to "boot") and
+        correction="romano_wolf" apply together (the realistic compound
+        case), both must still produce fully valid output -- exercises that
+        sharing the one joint bootstrap resample between the two
+        constructions doesn't corrupt either."""
+        evaldata = _make_multiarm_binary(n_entities=4, n_items=150, n_labeled=60, seed=206)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+            result = es.compare(
+                evaldata, factors="model", metric="llm_score",
+                alignment={"llm_score": ar}, n_mc=30,
+                simultaneous_ci=True, correction="romano_wolf",
+                rng=_rng(206),
+            )
+        bundle = result._primary_bundle()
+        assert bundle.pairwise.simultaneous_ci_method == "boot"
+        assert bundle.pairwise.correction_method == "romano_wolf"
+        for pr in bundle.pairwise.results.values():
+            assert np.isfinite(pr.ci_low) and np.isfinite(pr.ci_high)
+            assert pr.ci_low <= pr.ci_high
+            assert 0.0 <= pr.p_value <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Calibration tests (slower: repeated end-to-end compare() calls under a
+# known ground truth). These are the "does the compound path actually hold
+# up" checks the existing simulations don't cover -- FWER control and power
+# with alignment= AND simultaneous_ci=/correction= layered together, run
+# through the same compare() entrypoint a real user would call.
+# ---------------------------------------------------------------------------
+
+class TestCompoundCalibration:
+    N_REPS_NULL = 300
+    N_REPS_POWER = 150
+
+    def test_fwer_controlled_under_null_with_noisy_judge(self):
+        """4 arms, truly equal (null), a noisy judge (85% agreement) providing
+        sparse alignment labels, default method="auto" + simultaneous_ci=True
+        + correction="shaffer" -- exactly the default compound path a real
+        user hits. Empirical family-wise error rate (>= 1 pairwise p-value
+        < alpha across the 6 pairs) should stay near alpha, not run hot."""
+        alpha = 0.05
+        n_reject = 0
+        for i in range(self.N_REPS_NULL):
+            evaldata = _make_multiarm_binary(
+                n_entities=4, n_items=150, n_labeled=60,
+                p_base=0.55, effect_size=0.0, agreement_rate=0.85, seed=1000 + i,
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+                result = es.compare(
+                    evaldata, factors="model", metric="llm_score",
+                    alignment={"llm_score": ar}, n_mc=30,
+                    simultaneous_ci=True, correction="shaffer",
+                    rng=_rng(1000 + i),
+                )
+            bundle = result._primary_bundle()
+            if any(pr.p_value < alpha for pr in bundle.pairwise.results.values()):
+                n_reject += 1
+
+        fwer_hat = n_reject / self.N_REPS_NULL
+        # Binomial SE at alpha=0.05, N=300 is ~0.0126; allow a generous band
+        # (matching this project's practice of tolerating some MC noise at
+        # moderate rep counts rather than over-fitting the threshold -- see
+        # the [[multiarm_bootstrap_n_calibration]] memory) before calling it
+        # miscalibrated.
+        assert fwer_hat <= 0.12, (
+            f"Empirical FWER {fwer_hat:.3f} over {self.N_REPS_NULL} reps is too far "
+            f"above the nominal alpha={alpha} for the compound PPI+FWER path."
+        )
+
+    def test_compound_correction_power_cost_is_bounded(self):
+        """Characterizes (does not just sanity-check) how much detection
+        power the compound path costs relative to its own layers in
+        isolation, for a true effect size (0.30 probability gap over 4 arms,
+        n=150/arm) that is a virtual lock to detect on raw, uncorrected data.
+
+        Empirically (see this test's own measurements, run during
+        development): RAW (no PPI, no FWER) detects it ~100% of the time;
+        PPI alone (Tango, the auto-picked binary method, fixed lambda=1 --
+        no power-tuning) already costs real power on its own (observed
+        ~50%) because its variance decomposes into two DISJOINT terms
+        (Var(unlabeled diffs)/n_unlab + Var(rectifier)/n_lab -- see
+        evalstats.tests._ppi_paired_tango / _ppi_single_wilson) that can
+        each be noisy at moderate label fractions/judge agreement; stacking
+        Bonferroni-widened simultaneous CIs + Shaffer p-value correction on
+        top compounds that further (observed ~15-35%, seed-dependent).
+
+        This is NOT flagged as a bug -- both layers are individually valid,
+        conservative corrections, and there is no free lunch for controlling
+        both judge-noise bias AND family-wise error at once with a fixed
+        (non-power-tuned) PPI estimator. But the MAGNITUDE is a genuine
+        production-readiness consideration: a real, easily-detectable
+        difference can become only occasionally detectable once alignment +
+        simultaneous_ci + correction are all layered together, at the label
+        fractions/agreement rates likely to occur in practice. The bar below
+        is intentionally loose (not "power > 0.5") -- it only guards against
+        the compound path being degenerate/near-zero power, not against the
+        (expected, real) cost documented above.
+        """
+        alpha = 0.05
+        n_detected = 0
+        for i in range(self.N_REPS_POWER):
+            evaldata = _make_multiarm_binary(
+                n_entities=4, n_items=150, n_labeled=60,
+                p_base=0.55, effect_size=0.30, agreement_rate=0.85, seed=2000 + i,
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+                result = es.compare(
+                    evaldata, factors="model", metric="llm_score",
+                    alignment={"llm_score": ar}, n_mc=30,
+                    simultaneous_ci=True, correction="shaffer",
+                    rng=_rng(2000 + i),
+                )
+            bundle = result._primary_bundle()
+            pw = bundle.pairwise
+            p = pw.get("M0", "M3").p_value  # widest true gap by construction
+            if p is not None and p < alpha:
+                n_detected += 1
+
+        power_hat = n_detected / self.N_REPS_POWER
+        # Loose floor: guards against a total-power-loss regression (e.g. a
+        # sign error or a mis-wired correction stacking two full FWER
+        # divisions), not against the substantial-but-real cost documented
+        # above. Binomial SE at a true rate of ~0.35 over 150 reps is ~0.039;
+        # 0.15 sits ~5 SEs below that, i.e. this only fires if something is
+        # actually broken.
+        assert power_hat > 0.15, (
+            f"Compound PPI+FWER path only detected the largest true effect in "
+            f"{power_hat:.2f} of {self.N_REPS_POWER} reps -- this is at or below "
+            "the nominal alpha and suggests the compound path has become "
+            "essentially powerless, not just conservative."
+        )
+
+
+# ---------------------------------------------------------------------------
+# PPI-generalized Romano-Wolf calibration (slower). Confirms, on the SAME
+# scenario the Shaffer-based compound calibration above uses, that
+# Romano-Wolf (a) doesn't inflate FWER past nominal and (b) recovers some
+# real power over Shaffer -- the two claims backing making it the "auto"
+# default at N >= 30 (see PPI-generalized Romano-Wolf's own docstring,
+# _ppi_romano_wolf_pvalues_from_joint_stats, for why the recovery is real
+# but smaller than the non-PPI case's).
+# ---------------------------------------------------------------------------
+
+class TestRomanoWolfCalibration:
+    N_REPS_NULL = 200
+    N_REPS_POWER = 150
+
+    def test_romano_wolf_fwer_controlled_under_null(self):
+        alpha = 0.05
+        n_reject = 0
+        for i in range(self.N_REPS_NULL):
+            evaldata = _make_multiarm_binary(
+                n_entities=4, n_items=150, n_labeled=60,
+                p_base=0.55, effect_size=0.0, agreement_rate=0.85, seed=3000 + i,
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+                result = es.compare(
+                    evaldata, factors="model", metric="llm_score",
+                    alignment={"llm_score": ar}, n_mc=30,
+                    simultaneous_ci=False, correction="romano_wolf",
+                    rng=_rng(3000 + i),
+                )
+            bundle = result._primary_bundle()
+            if any(pr.p_value < alpha for pr in bundle.pairwise.results.values()):
+                n_reject += 1
+
+        fwer_hat = n_reject / self.N_REPS_NULL
+        # Same generous band as the Shaffer/compound calibration above --
+        # see [[multiarm_bootstrap_n_calibration]] on tolerating MC noise at
+        # moderate rep counts rather than over-fitting the threshold.
+        assert fwer_hat <= 0.12, (
+            f"Empirical FWER {fwer_hat:.3f} over {self.N_REPS_NULL} reps is too far "
+            f"above the nominal alpha={alpha} for PPI-generalized Romano-Wolf."
+        )
+
+    def test_romano_wolf_power_not_worse_than_shaffer(self):
+        """Romano-Wolf should recover SOME power over Shaffer on the same
+        data (paired comparison, same seeds) -- not dramatically, since
+        PPI's own p-value noise degrades the rank-reliability step-down
+        needs to gain from (see the compound-scenario investigation this
+        test file's docstring references), but it shouldn't be WORSE.
+        Loose bound (not requiring strict per-rep improvement) to avoid MC
+        noise false failures at this rep count."""
+        alpha = 0.05
+        n_detect_shaffer = 0
+        n_detect_rw = 0
+        for i in range(self.N_REPS_POWER):
+            evaldata = _make_multiarm_binary(
+                n_entities=4, n_items=150, n_labeled=60,
+                p_base=0.55, effect_size=0.30, agreement_rate=0.85, seed=4000 + i,
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                ar = validate_alignment(evaldata, llm_metric="llm_score", human_groundtruth="human_score")
+                result_shaffer = es.compare(
+                    evaldata, factors="model", metric="llm_score",
+                    alignment={"llm_score": ar}, n_mc=30,
+                    simultaneous_ci=False, correction="shaffer",
+                    rng=_rng(4000 + i),
+                )
+                result_rw = es.compare(
+                    evaldata, factors="model", metric="llm_score",
+                    alignment={"llm_score": ar}, n_mc=30,
+                    simultaneous_ci=False, correction="romano_wolf",
+                    rng=_rng(4000 + i),
+                )
+            p_shaffer = result_shaffer._primary_bundle().pairwise.get("M0", "M3").p_value
+            p_rw = result_rw._primary_bundle().pairwise.get("M0", "M3").p_value
+            if p_shaffer is not None and p_shaffer < alpha:
+                n_detect_shaffer += 1
+            if p_rw is not None and p_rw < alpha:
+                n_detect_rw += 1
+
+        power_shaffer = n_detect_shaffer / self.N_REPS_POWER
+        power_rw = n_detect_rw / self.N_REPS_POWER
+        # Binomial SE at ~0.3 over 150 reps is ~0.037; allow Romano-Wolf to
+        # be up to ~2 SEs below Shaffer before treating it as a regression,
+        # since the two are correlated (paired on the same data) and the
+        # theoretical expectation is Romano-Wolf >= Shaffer, not <.
+        assert power_rw >= power_shaffer - 0.08, (
+            f"Romano-Wolf power ({power_rw:.3f}) is meaningfully worse than "
+            f"Shaffer's ({power_shaffer:.3f}) on the same data -- Romano-Wolf "
+            "should recover power, not lose it."
+        )


### PR DESCRIPTION
## Summary

The compound scenario (`alignment=` combined with `simultaneous_ci=`/`correction=` on a k>=3 comparison) was under-supported: the CI side was permanently stuck on a Bonferroni fallback (an N-threshold bug compared total dataset size against the per-entity item count, and the auto-resolution table only ever offered `bonferroni`/`max_t`, never the more powerful Sidak/joint-bootstrap the non-PPI path uses), the p-value side had no Romano-Wolf equivalent at all, and `correction="auto"` crashed outright since the PPI path never resolved it.

- Fixed a real `ZeroDivisionError` crash: PPI correction on an entity/pair with 100% human-labeled items divided by a zero-length unlabeled sample; now raises a clear `ValueError` via a shared `_ppi_require_unlabeled` guard.
- Fixed the per-entity-N bug and generalized the compound CI-side auto-resolution to mirror the non-PPI tree exactly: `"sidak"` for small N, `"boot"` (joint bootstrap with an effective alpha) for larger N. Max-T is no longer an auto-resolved outcome anywhere (matching evalstats' decision tree, which has no max-T node) — reachable only via an explicit `prefer="max_t"` request.
- Built a PPI-generalized Romano-Wolf step-down p-value correction, reusing the same joint bootstrap resample `"boot"` needs (computed once, shared between both when both apply). `correction="auto"` now resolves to `"romano_wolf"` at N>=30, falling back to `"shaffer"` below that threshold or when the required shared-labeled-item structure isn't available.
- **Validated before flipping the default**: a 9-condition grid (k=3-5 arms, N=50-200, label fractions 20-40%, binary data, paired Shaffer-vs-Romano-Wolf on identical data) found worst-case FWER 0.067 against nominal 0.05 (within normal Monte Carlo noise, no systematic inflation) and power at or above Shaffer's in every condition tested (0/9 regressions).
- Fixed two more bugs found along the way: `bundle.pairwise.correction_method` was never updated by the PPI path (silently kept whatever the initial non-PPI pass had set); the Wilcoxon companion p-value correction would have crashed passing `"romano_wolf"` into `correct_pvalues()` (which doesn't know that method) — now substitutes Shaffer's for that family instead.
- Added `tests/test_compound_ppi_fwer.py`: 23 tests covering structural plumbing, the PPI Romano-Wolf integration, and calibration (FWER/power) for the compound scenario end-to-end via `compare()`.
- Added `examples/compare_alignment_ppi_fwer.py` demonstrating PPI + FWER control together on a 4-model comparison, showing both resolved constructions and the real (bounded, not total) power cost of stacking both corrections.

Merged with `main`'s Pareto-front/secondary-metrics work (unrelated feature area, clean auto-merge, no conflicts).

## Test plan
- [x] `tests/test_compound_ppi_fwer.py`: 23/23 passing (structural, Romano-Wolf integration, calibration)
- [x] `tests/test_alignment.py`: 55/55
- [x] `tests/test_ppi_ci_methods.py` + `test_ppi_core.py` + `test_simultaneous_ci.py` + `test_compare.py`: 164/164
- [x] `tests/test_ppi_corrections.py`: 319/319
- [x] `tests/test_pareto.py` (merged-in feature from main): 42/42
- [x] Manually verified `examples/compare_alignment_ppi_fwer.py` end-to-end, confirming `simultaneous_ci_method="boot"` and `correction_method="romano_wolf"` both resolve by default